### PR TITLE
Handle multiple endpoint infos in a single page

### DIFF
--- a/bin/main.dart
+++ b/bin/main.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:convert';
 
 import 'package:html/dom.dart';
+import 'package:meetup_api_scraper/enums/operation_type.dart';
 import 'package:meetup_api_scraper/scraper.dart';
 
 void main(List<String> arguments) async {
@@ -16,28 +17,39 @@ void main(List<String> arguments) async {
   final apiIndex = await scraper.scrapeApiIndex();
 
   final sectionFor = <String, String>{};
-  final endpointPaths = <String>{};
+  final idValuesForPath = <String, List<String>>{};
 
   // put all of the urls into a set & map each one to the section it is in
   for (final tag in apiIndex.getElementsByTagName('h4')) {
     final section = tag.text;
     for (final child in tag.nextElementSibling?.children ?? <Element>[]) {
       final endpointPath = child.children.first.children.elementAt(1).text;
+      final operatonTypeString =
+          child.children.first.children.elementAt(0).text;
+      final operationTypeEnum = OperationTypeEnum.from(operatonTypeString);
       sectionFor[endpointPath] = section;
-      endpointPaths.add(endpointPath);
+      (idValuesForPath[endpointPath] ??= <String>[])
+          .add(OperationTypeEnum.idValueOf[operationTypeEnum]!);
     }
   }
 
-  final element = await scraper.scrape(endpoint: endpointPaths.first);
+  // final element = await scraper.scrape(endpoint: endpointPaths.first);
 
-  print(element.outerHtml);
+  // print(element.outerHtml);
 
-  // for (final path in endpointPaths) {
-  //   final element = await scraper.scrape(endpoint: path);
-  //   print(element.innerHtml);
-  // }
+  for (final path in idValuesForPath.keys) {
+    final element = await scraper.scrape(endpoint: path);
 
-  await writeFile();
+    // final idValues = idValuesForPath[path] ?? [];
+    // for (final idValue in idValues) {
+    //   element.querySelector('div[id="$idValue"]');
+    //   await File(
+    //           'test/data/endpoint_infos/$idValue${path.replaceAll('/', '_')}.html')
+    //       .writeAsString(element.innerHtml);
+    // }
+  }
+
+  // await writeFile();
 }
 
 Future<File> writeFile() {

--- a/lib/enums/operation_type.dart
+++ b/lib/enums/operation_type.dart
@@ -9,4 +9,18 @@ class OperationTypeEnum {
     }
     return OperationType.unknown;
   }
+
+  static const List<String> idValues = [
+    'post',
+    'get',
+    'delete',
+    'edit',
+  ];
+
+  static const Map<OperationType, String> idValueOf = {
+    OperationType.post: 'post',
+    OperationType.get: 'get',
+    OperationType.delete: 'delete',
+    OperationType.patch: 'edit',
+  };
 }

--- a/lib/models/endpoint_info.dart
+++ b/lib/models/endpoint_info.dart
@@ -10,13 +10,44 @@ import 'package:meetup_api_scraper/models/endpoint_info/response.dart';
 // final h3Tags = element.getElementsByTagName('h3');
 // h4 - none
 class EndpointInfo {
+  // Each endpoint has it's own page at meetup_api/docs/<endpoint>
+  EndpointInfo(String title, String idPrefix, Document document, int position)
+      : _title = title,
+        _summary = document
+            .getElementsByClassName('leading-top')
+            .elementAt(position)
+            .text {
+    // elements that will be re-used
+    final requestUriInfos = document
+        .querySelectorAll(r'div[title="Request URI"]')
+        .elementAt(position)
+        .text
+        .trim()
+        .split(' ');
+
+    // Request URI info at the start
+    _path = requestUriInfos.last;
+    _operationType = OperationTypeEnum.from(requestUriInfos.first);
+
+    // The 3 major sections
+    final paramsElement = document.getElementById('${idPrefix}params')!;
+    final responseElement = document.getElementById('${idPrefix}response')!;
+    final examplesElement = document.getElementById('${idPrefix}examples');
+    _requestParameters =
+        RequestParameters.fromElement(paramsElement.nextElementSibling!);
+    _response = Response.fromElement(responseElement.nextElementSibling!);
+    _examples = (examplesElement == null)
+        ? null
+        : Examples.fromElement(examplesElement.nextElementSibling!);
+  }
+
   final String _title;
   final String _summary;
-  final String _path;
-  final OperationType _operationType;
-  final RequestParameters _requestParameters;
-  final Response _response;
-  final Examples? _examples;
+  late final String _path;
+  late final OperationType _operationType;
+  late final RequestParameters _requestParameters;
+  late final Response _response;
+  late final Examples? _examples;
 
   String get title => _title;
   String get summary => _summary;
@@ -29,35 +60,4 @@ class EndpointInfo {
   @override
   String toString() =>
       'title: $_title\n\nsummary: $_summary\n\npath: $_path\n\noperationType: $_operationType\n\nrequestParameters: $_requestParameters\n\nresponse: $_response\n\n examples: $_examples';
-
-  // Each endpoint has it's own page at meetup_api/docs/<endpoint>
-  EndpointInfo.fromElement(Element element)
-      : _title = element.getElementsByTagName('h2').first.text,
-        _summary = element.getElementsByTagName('p').first.text,
-        _path = element
-                .querySelector(r'div[title="Request URI"]')
-                ?.text
-                .trim()
-                .split(' ')
-                .last ??
-            '-',
-        _operationType = OperationTypeEnum.from(element
-                .querySelector(r'div[title="Request URI"]')
-                ?.text
-                .trim()
-                .split(' ')
-                .first ??
-            ''),
-        _requestParameters = RequestParameters.fromElement(
-            element.getElementsByTagName('h3').first.nextElementSibling!),
-        _response = Response.fromElement(element
-            .getElementsByTagName('h3')
-            .elementAt(1)
-            .nextElementSibling!),
-        _examples = (element.getElementsByTagName('h3').length > 2)
-            ? Examples.fromElement(element
-                .getElementsByTagName('h3')
-                .elementAt(2)
-                .nextElementSibling!)
-            : null;
 }

--- a/test/data/_:urlname.html
+++ b/test/data/_:urlname.html
@@ -1,0 +1,3275 @@
+
+        
+
+<div id="get">
+  <h2>Get Group</h2>
+  <div id="geturi" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Fetches a Meetup group by urlname</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname">Try it in the console</a></p>
+  <h3 id="getparams" class="rounded-all">Request Parameters</h3>
+  <div class="getparam-notes"><p>Only the path parameter :urlname is required</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional fields to append to the response</p></dd>
+  
+  </dl>
+  
+  <h3 id="getresponse" class="rounded-all">Response</h3>
+  <p>A successful response will include a
+representation of the group as a JSON object</p>
+  <dl>
+   
+    <dt class="align-right bold" title="approved"><span class="">approved</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean indicator for whether this Group has been approved or not.
+New Groups are generally approved (or removed)
+soon after creation.
+Returned when the "fields" request parameter value includes
+"approved"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="category"><span class="">category</span></dt>
+    <dd class="rounded-all">
+    <p>The primary category of the group, if the group has one</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric category id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>String identifier of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name used for sorting</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city_link"><span class="">city_link</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, a URL for the group's city</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="contributions"><span class="">contributions</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field containing the contribution details of the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="enabled"><span class="">enabled</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean stating if contributions are enabled for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="potential"><span class="">potential</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean stating that potential contributions are enabled for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="reason"><span class="">reason</span></dt>
+       <dd class="rounded-all">
+        <p>The reason a member might consider contributing</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thanks"><span class="">thanks</span></dt>
+       <dd class="rounded-all">
+        <p>The 'thank you' message to be given when a contribution is made</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time the group was created in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>Short description of group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="discussion_count"><span class="">discussion_count</span></dt>
+    <dd class="rounded-all">
+    <p>The total number of the group's discussions. Returned when the
+'fields' request parameter
+value contains 'discussion_count'
+and the group's 'visibility' setting permits it</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="discussion_preferences"><span class="">discussion_preferences</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field that contains preference and permission data for group discussions</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="discussion_sample"><span class="">discussion_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small sampling of the group's discussions. Returned when the
+'fields' request parameter
+value contains 'discussion_sample'
+and the group's 'visibility' setting permits it</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>long representing the time the discussion was created, measured by number of milliseconds from the Java epoch of 1970-01-01T00:00:00Z</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="creator"><span class="">creator</span></dt>
+       <dd class="rounded-all">
+        <p>Member who created the discussion</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+            <dd class="rounded-all"><p>Member bio. When profile does not belong to the authenticated member, this may be omitted if member opted to hide their bio from others</p></dd>
+            
+            <dt class="align-right bold" title="birthday"><span class="">birthday</span></dt>
+            <dd class="rounded-all"><p>Returned only when the fields request parameter value includes 'birthday'
+and only for the authenticated member when defined</p></dd>
+            
+            <dt class="align-right bold" title="city"><span class="">city</span></dt>
+            <dd class="rounded-all"><p>City associated with Member's location</p></dd>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country code associated with Member's location</p></dd>
+            
+            <dt class="align-right bold" title="email"><span class="">email</span></dt>
+            <dd class="rounded-all"><p>Member email address. Provided only if a profile belongs to the authenticated member</p></dd>
+            
+            <dt class="align-right bold" title="gender"><span class="">gender</span></dt>
+            <dd class="rounded-all"><p>Returned only when the fields request parameter value includes "gender"
+and only for the authenticated member.
+Value may be one of "female", "male", "none", or "other".
+This field may be absent where gender is not defined</p></dd>
+            
+            <dt class="align-right bold" title="group_profile"><span class="">group_profile</span></dt>
+            <dd class="rounded-all"><p>Meetup Group profile information.
+This field is only returned when profile is requested in group contexts</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the member</p></dd>
+            
+            <dt class="align-right bold" title="is_pro_admin"><span class="">is_pro_admin</span></dt>
+            <dd class="rounded-all"><p>Returns true if the member is an active admin of an active meetup pro network</p></dd>
+            
+            <dt class="align-right bold" title="joined"><span class="">joined</span></dt>
+            <dd class="rounded-all"><p>Time member joined, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Geographic latitude associated with Member's location</p></dd>
+            
+            <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+            <dd class="rounded-all"><p>Name of country associated with Member's location</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Geographic longitude associated with Member's location</p></dd>
+            
+            <dt class="align-right bold" title="messaging_pref"><span class="">messaging_pref</span></dt>
+            <dd class="rounded-all"><p>The member's preference for being contacted from other members on the platform.
+Returned only when the fields request parameter value includes "messaging_pref".
+May be one of the following: "all_members", "groups_only", or "orgs_only"</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name for the member</p></dd>
+            
+            <dt class="align-right bold" title="other_services"><span class="">other_services</span></dt>
+            <dd class="rounded-all"><p>An object whose key's are the names of associated external
+networks and values are identities within those networks.
+The keys may be one of facebook, flickr, linkedin, tumblr or twitter.
+Returned only when "fields" request parameter value
+includes "other_services"</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Member photo. May be absent if member has not chosen one.
+In group contexts, the Member's Group profile photo will be returned.</p></dd>
+            
+            <dt class="align-right bold" title="privacy"><span class="">privacy</span></dt>
+            <dd class="rounded-all"><p>Member's privacy preferences
+Returned only when the "fields" request parameter value includes "privacy"</p></dd>
+            
+            <dt class="align-right bold" title="self"><span class="">self</span></dt>
+            <dd class="rounded-all"><p>Represents the authenticated member's relation to member.
+Returned when "fields" request parameter value includes "self" and
+the target member is not the authenticated member</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State associated with Member's location, where available</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>a string with one of the following values: {'active', 'prereg', 'unknown'}</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="deleted"><span class="">deleted</span></dt>
+       <dd class="rounded-all">
+        <p>boolean representing whether the discussion is deleted</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="description"><span class="">description</span></dt>
+       <dd class="rounded-all">
+        <p>Content of the discussion</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>The Group associated with the discussion</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>long representing the time the group was created, measured by number of seconds from the Java epoch of 1970-01-01T00:00:00Z</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>integer representing unique group id</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>string representing join mode of the group, which can be one of {open, approval, closed}</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>float representing latitude of the group</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>float representing longitude of the group</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>name of the group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Urlname used to identify the group</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique string identifier of the discussion</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="like_count"><span class="">like_count</span></dt>
+       <dd class="rounded-all">
+        <p>an integer representing the number of likes for this discussion</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="num_comments"><span class="">num_comments</span></dt>
+       <dd class="rounded-all">
+        <p>an integer representing the number of comments in this discussion</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="num_follows"><span class="">num_follows</span></dt>
+       <dd class="rounded-all">
+        <p>an integer representing the number of follows in this discussion</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="report_link"><span class="">report_link</span></dt>
+       <dd class="rounded-all">
+        <p>string representing the url for reporting abuse on this discussion</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self"><span class="">self</span></dt>
+       <dd class="rounded-all">
+        
+        
+          <dl>
+            
+            <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+            <dd class="rounded-all"><p>an array of strings that each represent an action the member is allowed to take on the discussion. Can include zero or more of the following: {Delete, FlagSpam, Comment, Follow, Unfollow, Like, Unlike}</p></dd>
+            
+            <dt class="align-right bold" title="followed"><span class="">followed</span></dt>
+            <dd class="rounded-all"><p>a boolean representing whether the member is following the discussion</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>long representing the time the discussion was most recently modified, measured by number of milliseconds from the Java epoch of 1970-01-01T00:00:00Z</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>integer representing the utc time offset translated from meetup server time offset</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visible"><span class="">visible</span></dt>
+       <dd class="rounded-all">
+        <p>boolean representing whether the discussion is visible</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="draft_event_count"><span class="">draft_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of draft events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="event_sample"><span class="">event_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small sampling of recent past events with photos.
+Returned when the "fields" request parameter
+value contains "event_sample"
+ and the group's "visibility" setting permits it</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+       <dd class="rounded-all">
+        <p>Is event date matches the series pattern</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+       <dd class="rounded-all">
+        <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Ticketing fee information for events that support payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+            <dd class="rounded-all"><p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p></dd>
+            
+            <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+            <dd class="rounded-all"><p>Amount of the fee</p></dd>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Fee description, typically "per-person"</p></dd>
+            
+            <dt class="align-right bold" title="label"><span class="">label</span></dt>
+            <dd class="rounded-all"><p>Label for fee, typically "Price"</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>Boolean flag indicating if this fee is required to RSVP</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>A unique alphanumeric identifier for event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+       <dd class="rounded-all">
+        <p>Is event happening online</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+       <dd class="rounded-all">
+        <p>The local date of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+       <dd class="rounded-all">
+        <p>The local time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+       <dd class="rounded-all">
+        <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+       <dd class="rounded-all">
+        <p>Information about photo uploads for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="event"><span class="">event</span></dt>
+            <dd class="rounded-all"><p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for photo album</p></dd>
+            
+            <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+            <dd class="rounded-all"><p>Number of photos uploaded</p></dd>
+            
+            <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+            <dd class="rounded-all"><p>A small collection of photos uploaded for this event</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Album title</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+       <dd class="rounded-all">
+        <p>The number of "yes" RSVPS an event has capacity for</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection RSVPs for members attending this event, returned when the "fields" request parameter value includes "rsvp_sample"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>Creation time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p></dd>
+            
+            <dt class="align-right bold" title="member"><span class="">member</span></dt>
+            <dd class="rounded-all"><p>Member who RSVP'd</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>Last modified time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="series"><span class="">series</span></dt>
+       <dd class="rounded-all">
+        <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Human displayable description of how often events in this series occur</p></dd>
+            
+            <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series ends/ended, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the series</p></dd>
+            
+            <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a monthly recurring series of events</p></dd>
+            
+            <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series begins/began, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the template event of the series</p></dd>
+            
+            <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a weekly recurring series of events</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+       <dd class="rounded-all">
+        <p>Contains a list of organizer-defined survey questions intended to be asked of RSVPing members.
+Returned when the "fields" request parameter
+contains "survey_questions"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric question identifier</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time for the event in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+       <dd class="rounded-all">
+        <p>The event venue, present only if selected and not hidden by an organizer</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+            <dd class="rounded-all"><p>Line 1 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+            <dd class="rounded-all"><p>Line 2 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+            <dd class="rounded-all"><p>Line 3 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="city"><span class="">city</span></dt>
+            <dd class="rounded-all"><p>City of venue</p></dd>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country code of venue</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric venue id</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+            <dd class="rounded-all"><p>The localized name of the venue's country</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Venue name</p></dd>
+            
+            <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+            <dd class="rounded-all"><p>Phone number of venue</p></dd>
+            
+            <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+            <dd class="rounded-all"><p>true if the editor of the event altered the original venues pin location, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of venue where available</p></dd>
+            
+            <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+            <dd class="rounded-all"><p>ZIP code if, venue is in US or Canada</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of members on the waitlist, if one exists</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs including guests</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee_options"><span class="">fee_options</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, returns payment options for event ticketing</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currencies"><span class="">currencies</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable currencies for the payment method specified by type</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="code"><span class="">code</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="default"><span class="">default</span></dt>
+            <dd class="rounded-all"><p>A boolean set to true if the currency is the group's default currency, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="is_setup"><span class="">is_setup</span></dt>
+       <dd class="rounded-all">
+        <p>A boolean set to true if the payment method specified by 'type' is set up for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="setup_link"><span class="">setup_link</span></dt>
+       <dd class="rounded-all">
+        <p>The URL for setting up the payment method specified by 'type'. This is returned if the payment method specified by 'type' is not set up for the group and the member has the permission to set it up</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of Set(stripe, wepay, paypal, none, cash)</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Group photo</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric group ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_simplehtml"><span class="">is_simplehtml</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, 'true' when the group description has been saved in a simplified HTML format, 'false' otherwise.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_info"><span class="">join_info</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, lists any questions requested when joining and required fields</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="photo_req"><span class="">photo_req</span></dt>
+       <dd class="rounded-all">
+        <p>true if required, false otherwise</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="questions"><span class="">questions</span></dt>
+       <dd class="rounded-all">
+        <p>List of profile questions organizer would like new members to answer prior to joining</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the question</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>The text of the question</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="questions_req"><span class="">questions_req</span></dt>
+       <dd class="rounded-all">
+        <p>true if required, false otherwise</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+    <dd class="rounded-all">
+    <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Group primary photo</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+    <dd class="rounded-all">
+    <p>Lang of founder or coordinator</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="last_event"><span class="">last_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the last hosted event, if the group has one. Returned when the "fields" request parameter value contains "last_event"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Latitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="leader_limit"><span class="">leader_limit</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup leaders limit in group (4 leaders for the Basic Subscription), note this info available only for orgs and coorgs</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="leads"><span class="">leads</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the number of members on this group's leadership team. Returned when the "fields" request parameter value contains "leads"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to group on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="list_addr"><span class="">list_addr</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field returning list address prefix. List mail will be {list_addr}-list@meetup.com. Announce email will be {list_addr}-announce@meetup.com. You must be a member of the group to see this</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="list_mode"><span class="">list_mode</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the policy for who can post the group mailing list. Returned when the "fields" request parameter value contains "list_mode". Value may be one of "moderated", "off", "open", or "orgs_only"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+    <dd class="rounded-all">
+    <p>City/State or City/Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Longitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_cap"><span class="">member_cap</span></dt>
+    <dd class="rounded-all">
+    <p>Number representing the maximum number of active members this group can have if capped. Returned only when requested in the fields request parameter and the authenticated member has permission to approve members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_limit"><span class="">member_limit</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup members limit in group (now it's 50 members in the Basic Subscription)</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_sample"><span class="">member_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small sampling of active members. Returned when the
+'fields' request parameter
+value contains 'member_sample'
+and the group's 'visibility' setting permits it</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Member bio. When profile does not belong to the authenticated member, this may be omitted if member opted to hide their bio from others</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="birthday"><span class="">birthday</span></dt>
+       <dd class="rounded-all">
+        <p>Returned only when the fields request parameter value includes 'birthday'
+and only for the authenticated member when defined</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="day"><span class="">day</span></dt>
+            <dd class="rounded-all"><p>Numeric day member was born. May be absent if not defined</p></dd>
+            
+            <dt class="align-right bold" title="month"><span class="">month</span></dt>
+            <dd class="rounded-all"><p>Numeric month member was born. May be absent if not defined</p></dd>
+            
+            <dt class="align-right bold" title="year"><span class="">year</span></dt>
+            <dd class="rounded-all"><p>Year member was born</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="city"><span class="">city</span></dt>
+       <dd class="rounded-all">
+        <p>City associated with Member's location</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country code associated with Member's location</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="email"><span class="">email</span></dt>
+       <dd class="rounded-all">
+        <p>Member email address. Provided only if a profile belongs to the authenticated member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="gender"><span class="">gender</span></dt>
+       <dd class="rounded-all">
+        <p>Returned only when the fields request parameter value includes "gender"
+and only for the authenticated member.
+Value may be one of "female", "male", "none", or "other".
+This field may be absent where gender is not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="is_pro_admin"><span class="">is_pro_admin</span></dt>
+       <dd class="rounded-all">
+        <p>Returns true if the member is an active admin of an active meetup pro network</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="joined"><span class="">joined</span></dt>
+       <dd class="rounded-all">
+        <p>Time member joined, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Geographic latitude associated with Member's location</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of country associated with Member's location</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Geographic longitude associated with Member's location</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="messaging_pref"><span class="">messaging_pref</span></dt>
+       <dd class="rounded-all">
+        <p>The member's preference for being contacted from other members on the platform.
+Returned only when the fields request parameter value includes "messaging_pref".
+May be one of the following: "all_members", "groups_only", or "orgs_only"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name for the member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="other_services"><span class="">other_services</span></dt>
+       <dd class="rounded-all">
+        <p>An object whose key's are the names of associated external
+networks and values are identities within those networks.
+The keys may be one of facebook, flickr, linkedin, tumblr or twitter.
+Returned only when "fields" request parameter value
+includes "other_services"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="identifier"><span class="">identifier</span></dt>
+            <dd class="rounded-all"><p>A unique string identifier</p></dd>
+            
+            <dt class="align-right bold" title="url"><span class="">url</span></dt>
+            <dd class="rounded-all"><p>A url for this identity. May be the same as identifier in some cases</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo. May be absent if member has not chosen one.
+In group contexts, the Member's Group profile photo will be returned.</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="privacy"><span class="">privacy</span></dt>
+       <dd class="rounded-all">
+        <p>Member's privacy preferences
+Returned only when the "fields" request parameter value includes "privacy"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+            <dd class="rounded-all"><p>may be 'hidden' or 'visible'</p></dd>
+            
+            <dt class="align-right bold" title="facebook"><span class="">facebook</span></dt>
+            <dd class="rounded-all"><p>may be 'hidden' of 'visible'.
+If absent, the member has not connected their Facebook account to Meetup</p></dd>
+            
+            <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+            <dd class="rounded-all"><p>may be 'hidden' or 'visible</p></dd>
+            
+            <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+            <dd class="rounded-all"><p>may be 'hidden' or 'visible'</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="self"><span class="">self</span></dt>
+       <dd class="rounded-all">
+        <p>Represents the authenticated member's relation to member.
+Returned when "fields" request parameter value includes "self" and
+the target member is not the authenticated member</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+            <dd class="rounded-all"><p>List of actions available for the authenticated member to perform.
+Currently only "message" is supported</p></dd>
+            
+            <dt class="align-right bold" title="blocks"><span class="">blocks</span></dt>
+            <dd class="rounded-all"><p>Boolean indication of whether or not the authenticated member blocks this member</p></dd>
+            
+            <dt class="align-right bold" title="common"><span class="">common</span></dt>
+            <dd class="rounded-all"><p>Information the authenticated member has in common with this member</p></dd>
+            
+            <dt class="align-right bold" title="friends"><span class="">friends</span></dt>
+            <dd class="rounded-all"><p>Boolean indication of whether or not the authenticated member is a friend of the member</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State associated with Member's location, where available</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>a string with one of the following values: {'active', 'prereg', 'unknown'}</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="members"><span class="">members</span></dt>
+    <dd class="rounded-all">
+    <p>Number of Meetup members in this group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, returns membership dues for group if any</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+       <dd class="rounded-all">
+        <p>Currency in which the fee is declared</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="dues_links"><span class="">dues_links</span></dt>
+       <dd class="rounded-all">
+        <p>Links to dues management and checkout pages.</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="checkout_url"><span class="">checkout_url</span></dt>
+            <dd class="rounded-all"><p>Dues checkout page URL</p></dd>
+            
+            <dt class="align-right bold" title="settings_url"><span class="">settings_url</span></dt>
+            <dd class="rounded-all"><p>(Organizers only) Dues settings page URL</p></dd>
+            
+            <dt class="align-right bold" title="start_url"><span class="">start_url</span></dt>
+            <dd class="rounded-all"><p>(Organizers only) Dues setup page URL</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric fee value</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee_desc"><span class="">fee_desc</span></dt>
+       <dd class="rounded-all">
+        <p>The interval at which dues must be paid. Possible values may include: "month", "year", "day", or "every other day"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="methods"><span class="">methods</span></dt>
+       <dd class="rounded-all">
+        <p>Methods of payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="amazon_payments"><span class="">amazon_payments</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Amazon Payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="credit_card"><span class="">credit_card</span></dt>
+            <dd class="rounded-all"><p>(Deprecated - use <code>wepay</code> or <code>stripe</code> instead) Boolean indicator that credit cards are accepted</p></dd>
+            
+            <dt class="align-right bold" title="other"><span class="">other</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that other forms of payment are accepted</p></dd>
+            
+            <dt class="align-right bold" title="paypal"><span class="">paypal</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Paypal payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="stripe"><span class="">stripe</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Stripe payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="wepay"><span class="">wepay</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Wepay payments are accepted</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="reasons"><span class="">reasons</span></dt>
+       <dd class="rounded-all">
+        <p>Array of reasons containing one or more of the following values compensate_organizer, cover_costs, encourage_engagement, improve_meetups, other, provide_supplies, reserve_fund</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="reasons_other"><span class="">reasons_other</span></dt>
+       <dd class="rounded-all">
+        <p>An additional reason if specified.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+       <dd class="rounded-all">
+        <p>Conditions for refunds</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="custom"><span class="">custom</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator of a custom refund policy</p></dd>
+            
+            <dt class="align-right bold" title="group_closes"><span class="">group_closes</span></dt>
+            <dd class="rounded-all"><p>refund applies when the group closes</p></dd>
+            
+            <dt class="align-right bold" title="member_banned"><span class="">member_banned</span></dt>
+            <dd class="rounded-all"><p>refund applies when the member is banned</p></dd>
+            
+            <dt class="align-right bold" title="member_leaves"><span class="">member_leaves</span></dt>
+            <dd class="rounded-all"><p>refund applies when member leaves the group</p></dd>
+            
+            <dt class="align-right bold" title="none"><span class="">none</span></dt>
+            <dd class="rounded-all"><p>indicates there is no refund policy</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="required"><span class="">required</span></dt>
+       <dd class="rounded-all">
+        <p>true if dues are required</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="required_to"><span class="">required_to</span></dt>
+       <dd class="rounded-all">
+        <p>If the dues are required this indicates what they are required for. Currently may only be 'join'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self_payment_required"><span class="">self_payment_required</span></dt>
+       <dd class="rounded-all">
+        <p>Returns true if the authorized user is prevented from participating in the group until a payment is made</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="trial_days"><span class="">trial_days</span></dt>
+       <dd class="rounded-all">
+        <p>When present, returns the number of days the group is offering a free trial period for to new members. When not present, this indicates that the group does not offer a trial membership period</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="meta_category"><span class="">meta_category</span></dt>
+    <dd class="rounded-all">
+    <p>The meta category of the group, if the group has one</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="best_topics"><span class="">best_topics</span></dt>
+       <dd class="rounded-all">
+        <p>Represents the best topic matches for this category, returned when the "fields"
+request parameter value includes "best_topics"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic id</p></dd>
+            
+            <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+            <dd class="rounded-all"><p>Language topic originates from</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic</p></dd>
+            
+            <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+            <dd class="rounded-all"><p>The unique keyword used to identify this topic</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="category_ids"><span class="">category_ids</span></dt>
+       <dd class="rounded-all">
+        <p>List of numeric category ids associated with this topic category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic-category id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic-category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Photo representing this category</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>Unique string identifier for this category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name used for sorting</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="next_event"><span class="">next_event</span></dt>
+    <dd class="rounded-all">
+    <p>The current ongoing or next upcoming event, if one is scheduled</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="nominated_member"><span class="">nominated_member</span></dt>
+    <dd class="rounded-all">
+    <p>True if the member was nominated for the most recent handover and has not declined the nomination, false otherwise</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="nomination_acceptable"><span class="">nomination_acceptable</span></dt>
+    <dd class="rounded-all">
+    <p>True if the group currently allows nominees to accept their handover nomination, false otherwise</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="organizer"><span class="">organizer</span></dt>
+    <dd class="rounded-all">
+    <p>Group's primary organizer</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Bio of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer photo, where defined</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="past_event_count"><span class="">past_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of past events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="pending_members"><span class="">pending_members</span></dt>
+    <dd class="rounded-all">
+    <p>Number representing the count of members pending organizer approval to join. Returned only when requested in the fields request parameter and the authenticated member has permission to approve members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+    <dd class="rounded-all">
+    <p>Color combination used generate group duotone</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+       <dd class="rounded-all">
+        <p>Composite color in hexidecimal format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+       <dd class="rounded-all">
+        <p>Dark color in hexidecimal format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+       <dd class="rounded-all">
+        <p>Light color in hexidecimal format</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photos"><span class="">photos</span></dt>
+    <dd class="rounded-all">
+    <p>A small set of photos from the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_description"><span class="">plain_text_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in plain text format. Returned when then "fields" request parameter value contains "plain_text_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_no_images_description"><span class="">plain_text_no_images_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in plain text format with no images. Returned when then "fields" request parameter value contains "plain_text_no_images_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="proposed_event_count"><span class="">proposed_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of proposed events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, contains details specific to the authorized user in this Meetup Group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform, potentially "broadcast_message": the ability to broadcast messages to group members via the "announce" mailing list, "event_create": the ability to create new events, "event_draft": the ability to save new events as drafts, "role_assign": the ability to assign member roles, "edit": the ability to edit group settings, "member_approval": the ability to approve or decline member requests to join, or "subscription_upgrade": the ability to upgrade this group's subscription plan</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Member's membership dues if the group has membership dues</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="cancelled"><span class="">cancelled</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that membership dues were cancelled</p></dd>
+            
+            <dt class="align-right bold" title="exempt"><span class="">exempt</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that the member is exempt from payment.</p></dd>
+            
+            <dt class="align-right bold" title="paid_until"><span class="">paid_until</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns the time in milliseconds since the epoch that the member's next payment is due</p></dd>
+            
+            <dt class="align-right bold" title="period_status"><span class="">period_status</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns one of the following values grace paid pending unpaid</p></dd>
+            
+            <dt class="align-right bold" title="total_amount"><span class="">total_amount</span></dt>
+            <dd class="rounded-all"><p>Total amount paid</p></dd>
+            
+            <dt class="align-right bold" title="transaction_time"><span class="">transaction_time</span></dt>
+            <dd class="rounded-all"><p>Time the transaction was made in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="trial"><span class="">trial</span></dt>
+            <dd class="rounded-all"><p>If the group offers a trial membership, this indicates information for unpaid members.</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="previous_membership_dues"><span class="">previous_membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Member's membership dues history when currently not a part of group i.e Status=none if the group has membership dues</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="cancelled"><span class="">cancelled</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that membership dues were cancelled</p></dd>
+            
+            <dt class="align-right bold" title="exempt"><span class="">exempt</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that the member is exempt from payment.</p></dd>
+            
+            <dt class="align-right bold" title="paid_until"><span class="">paid_until</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns the time in milliseconds since the epoch that the member's next payment is due</p></dd>
+            
+            <dt class="align-right bold" title="period_status"><span class="">period_status</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns one of the following values grace paid pending unpaid</p></dd>
+            
+            <dt class="align-right bold" title="total_amount"><span class="">total_amount</span></dt>
+            <dd class="rounded-all"><p>Total amount paid</p></dd>
+            
+            <dt class="align-right bold" title="transaction_time"><span class="">transaction_time</span></dt>
+            <dd class="rounded-all"><p>Time the transaction was made in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="trial"><span class="">trial</span></dt>
+            <dd class="rounded-all"><p>If the group offers a trial membership, this indicates information for unpaid members.</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>Member's role in group, if any: Organizer, Assistant Organizer, Event Organizer, etc.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Indicates the authorized user's membership with this group. Value may be one of "none", "pending", "pending_payment", "active", or "blocked"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+       <dd class="rounded-all">
+        <p>Member's last visit to the group site, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, a shorted URL for the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="similar_groups"><span class="">similar_groups</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns up to 5 groups similar to this groups, best suited for the authenticated member when a single group is queried for. Note: this field is being deprecated in favor of making a separate request to /:urlname/similar_groups</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Id of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photos"><span class="">photos</span></dt>
+       <dd class="rounded-all">
+        <p>Optional fields parameter. A small set of photos from the group</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What this group calls it's members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="simple_html_description"><span class="">simple_html_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in simple HTML source format. If this group's description was saved in simple HTML format, the description field will be an HTML translation of this source. Returned when the "fields" request parameter value contains "simple_html_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State of the group, if in US or Canada</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>Status of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+    <dd class="rounded-all">
+    <p>This represents the universal timezone identifier for the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the group's topics</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+       <dd class="rounded-all">
+        <p>Language topic originates from</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+       <dd class="rounded-all">
+        <p>The unique keyword used to identify this topic</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="untranslated_city"><span class="">untranslated_city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group, not translated</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="upcoming_event_count"><span class="">upcoming_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of upcoming events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+    <dd class="rounded-all">
+    <p>Urlname used to identify the group on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Who can see this group. One of members, public or public_limited</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="welcome_message"><span class="">welcome_message</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the Group's default welcome message if the authenticated member is the organizer of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="who"><span class="">who</span></dt>
+    <dd class="rounded-all">
+    <p>What the group calls its members</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="edit">
+  <h2>Group Edit</h2>
+  <div id="edituri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">group_edit</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Allows organizers to edit their Meetup group information. To change group topics, see the <a href="/meetup_api/docs/:urlname/topics/#add">add</a> and <a href="/meetup_api/docs/:urlname/topics/#remove">remove</a> topics endpoints. To change group photo use the <a href="/meetup_api/docs/2/group_photo/#create">Group photo upload</a> endpoint. OAuth authenticated requests require an additional <a href="/meetup_api/auth/#oauth2-scopes">group_edit</a> permission.</p>
+  </div>
+  
+  <h3 id="editparams" class="rounded-all">Request Parameters</h3>
+  <div class="editparam-notes"><p>All parameters are optional.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="add_topics"><span class="">add_topics</span></dt>
+    <dd class="rounded-all"><p>Comma-delimited list of topic ids to associate with group</p></dd>
+  
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all"><p>The ISO_3166-1 country code for the country which contains the city</p></dd>
+  
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all"><p>Summary of what the Meetup group is about in simple HTML format</p></dd>
+  
+    <dt class="align-right bold" title="dryrun"><span class="">dryrun</span></dt>
+    <dd class="rounded-all"><p>Boolean parameter that will cause this endpoint to apply all validation rules without actually saving changes in which case the response will only reflect the group's current attributes</p></dd>
+  
+    <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+    <dd class="rounded-all"><p>Controls how member's are let into the group. May be one of 'open' meaning any Meetup member my join, 'closed' meaning group is not currently accepting new members, or 'approval' meaning members must be approved by an organizer. Note, the 'closed' options is only available to groups that already have a 'closed' join_mode</p></dd>
+  
+    <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+    <dd class="rounded-all"><p>Group's primary photo. Must be ID of an existing album photo</p></dd>
+  
+    <dt class="align-right bold" title="list_addr"><span class="">list_addr</span></dt>
+    <dd class="rounded-all"><p>Mailing list prefix. By default this is the group's urlname.</p></dd>
+  
+    <dt class="align-right bold" title="list_mode"><span class="">list_mode</span></dt>
+    <dd class="rounded-all"><p>Defines policy for who can post to the group mailing list. May be one of 'open' meaning any member can post, 'off' meaning no one can post, 'moderated' meaning messages must be approved, or 'orgs_only' meaning only organizers may post to the list</p></dd>
+  
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all"><p>Display name of the group. Can be at most 60 characters</p></dd>
+  
+    <dt class="align-right bold" title="photo_req"><span class="">photo_req</span></dt>
+    <dd class="rounded-all"><p>Indicates that a member must provide a photo before joining. Expects true or false values</p></dd>
+  
+    <dt class="align-right bold" title="question_edit_{id}"><span class="">question_edit_{id}</span></dt>
+    <dd class="rounded-all"><p>Edits a current profile question identified by an id in the parameter name. The index updated index should also be encoded in the parameter name. To delete a question, set this to an empty string. Groups that require profile questions must have at least one question</p></dd>
+  
+    <dt class="align-right bold" title="question_{index}"><span class="">question_{index}</span></dt>
+    <dd class="rounded-all"><p>A new profile question defined in the order of index provided in the request parameter name</p></dd>
+  
+    <dt class="align-right bold" title="questions_req"><span class="">questions_req</span></dt>
+    <dd class="rounded-all"><p>Indicates that provided questions are required before joining. Expects true or false values</p></dd>
+  
+    <dt class="align-right bold" title="remove_topics"><span class="">remove_topics</span></dt>
+    <dd class="rounded-all"><p>Comma-delimited list of topic ids to disassociate with group</p></dd>
+  
+    <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+    <dd class="rounded-all"><p>Name used for the groups web address on meetup.com. Must be between 6 and 60 characters</p></dd>
+  
+    <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+    <dd class="rounded-all"><p>Restricts group visibility for non-members. May be one of 'public', 'public_limited' or 'members'. Note, the 'members' option is only available to groups that already have 'members' visibility</p></dd>
+  
+    <dt class="align-right bold" title="welcome_message"><span class="">welcome_message</span></dt>
+    <dd class="rounded-all"><p>Message sent to members after they join. Can be at most 2000 characters</p></dd>
+  
+    <dt class="align-right bold" title="who"><span class="">who</span></dt>
+    <dd class="rounded-all"><p>What members of the group will be called. Can be at most 32 characters</p></dd>
+  
+    <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+    <dd class="rounded-all"><p>The ZIP code of the city</p></dd>
+  
+    <dt class="align-right bold" title="{service}_uri"><span class="">{service}_uri</span></dt>
+    <dd class="rounded-all"><p>A URI for a social network service. Service must be one of facebook, flickr, other, tumblr, twitter</p></dd>
+  
+  </dl>
+  
+  <h3 id="editresponse" class="rounded-all">Response</h3>
+  <p>A successful response will include a representation of the updated group as a JSON object</p>
+  <dl>
+   
+    <dt class="align-right bold" title="approved"><span class="">approved</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean indicator for whether this Group has been approved or not.
+New Groups are generally approved (or removed)
+soon after creation.
+Returned when the "fields" request parameter value includes
+"approved"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="category"><span class="">category</span></dt>
+    <dd class="rounded-all">
+    <p>The primary category of the group, if the group has one</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric category id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>String identifier of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name used for sorting</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city_link"><span class="">city_link</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, a URL for the group's city</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="contributions"><span class="">contributions</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field containing the contribution details of the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="enabled"><span class="">enabled</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean stating if contributions are enabled for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="potential"><span class="">potential</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean stating that potential contributions are enabled for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="reason"><span class="">reason</span></dt>
+       <dd class="rounded-all">
+        <p>The reason a member might consider contributing</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thanks"><span class="">thanks</span></dt>
+       <dd class="rounded-all">
+        <p>The 'thank you' message to be given when a contribution is made</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time the group was created in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>Short description of group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="discussion_preferences"><span class="">discussion_preferences</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field that contains preference and permission data for group discussions</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="draft_event_count"><span class="">draft_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of draft events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee_options"><span class="">fee_options</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, returns payment options for event ticketing</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currencies"><span class="">currencies</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable currencies for the payment method specified by type</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="code"><span class="">code</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="default"><span class="">default</span></dt>
+            <dd class="rounded-all"><p>A boolean set to true if the currency is the group's default currency, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="is_setup"><span class="">is_setup</span></dt>
+       <dd class="rounded-all">
+        <p>A boolean set to true if the payment method specified by 'type' is set up for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="setup_link"><span class="">setup_link</span></dt>
+       <dd class="rounded-all">
+        <p>The URL for setting up the payment method specified by 'type'. This is returned if the payment method specified by 'type' is not set up for the group and the member has the permission to set it up</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of Set(stripe, wepay, paypal, none, cash)</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Group photo</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric group ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_simplehtml"><span class="">is_simplehtml</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, 'true' when the group description has been saved in a simplified HTML format, 'false' otherwise.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_info"><span class="">join_info</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, lists any questions requested when joining and required fields</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="photo_req"><span class="">photo_req</span></dt>
+       <dd class="rounded-all">
+        <p>true if required, false otherwise</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="questions"><span class="">questions</span></dt>
+       <dd class="rounded-all">
+        <p>List of profile questions organizer would like new members to answer prior to joining</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the question</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>The text of the question</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="questions_req"><span class="">questions_req</span></dt>
+       <dd class="rounded-all">
+        <p>true if required, false otherwise</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+    <dd class="rounded-all">
+    <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Group primary photo</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+    <dd class="rounded-all">
+    <p>Lang of founder or coordinator</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="last_event"><span class="">last_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the last hosted event, if the group has one. Returned when the "fields" request parameter value contains "last_event"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Latitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="leader_limit"><span class="">leader_limit</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup leaders limit in group (4 leaders for the Basic Subscription), note this info available only for orgs and coorgs</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="leads"><span class="">leads</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the number of members on this group's leadership team. Returned when the "fields" request parameter value contains "leads"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to group on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="list_addr"><span class="">list_addr</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field returning list address prefix. List mail will be {list_addr}-list@meetup.com. Announce email will be {list_addr}-announce@meetup.com. You must be a member of the group to see this</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="list_mode"><span class="">list_mode</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the policy for who can post the group mailing list. Returned when the "fields" request parameter value contains "list_mode". Value may be one of "moderated", "off", "open", or "orgs_only"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+    <dd class="rounded-all">
+    <p>City/State or City/Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Longitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_cap"><span class="">member_cap</span></dt>
+    <dd class="rounded-all">
+    <p>Number representing the maximum number of active members this group can have if capped. Returned only when requested in the fields request parameter and the authenticated member has permission to approve members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_limit"><span class="">member_limit</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup members limit in group (now it's 50 members in the Basic Subscription)</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="members"><span class="">members</span></dt>
+    <dd class="rounded-all">
+    <p>Number of Meetup members in this group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, returns membership dues for group if any</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+       <dd class="rounded-all">
+        <p>Currency in which the fee is declared</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="dues_links"><span class="">dues_links</span></dt>
+       <dd class="rounded-all">
+        <p>Links to dues management and checkout pages.</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="checkout_url"><span class="">checkout_url</span></dt>
+            <dd class="rounded-all"><p>Dues checkout page URL</p></dd>
+            
+            <dt class="align-right bold" title="settings_url"><span class="">settings_url</span></dt>
+            <dd class="rounded-all"><p>(Organizers only) Dues settings page URL</p></dd>
+            
+            <dt class="align-right bold" title="start_url"><span class="">start_url</span></dt>
+            <dd class="rounded-all"><p>(Organizers only) Dues setup page URL</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric fee value</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee_desc"><span class="">fee_desc</span></dt>
+       <dd class="rounded-all">
+        <p>The interval at which dues must be paid. Possible values may include: "month", "year", "day", or "every other day"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="methods"><span class="">methods</span></dt>
+       <dd class="rounded-all">
+        <p>Methods of payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="amazon_payments"><span class="">amazon_payments</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Amazon Payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="credit_card"><span class="">credit_card</span></dt>
+            <dd class="rounded-all"><p>(Deprecated - use <code>wepay</code> or <code>stripe</code> instead) Boolean indicator that credit cards are accepted</p></dd>
+            
+            <dt class="align-right bold" title="other"><span class="">other</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that other forms of payment are accepted</p></dd>
+            
+            <dt class="align-right bold" title="paypal"><span class="">paypal</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Paypal payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="stripe"><span class="">stripe</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Stripe payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="wepay"><span class="">wepay</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Wepay payments are accepted</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="reasons"><span class="">reasons</span></dt>
+       <dd class="rounded-all">
+        <p>Array of reasons containing one or more of the following values compensate_organizer, cover_costs, encourage_engagement, improve_meetups, other, provide_supplies, reserve_fund</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="reasons_other"><span class="">reasons_other</span></dt>
+       <dd class="rounded-all">
+        <p>An additional reason if specified.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+       <dd class="rounded-all">
+        <p>Conditions for refunds</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="custom"><span class="">custom</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator of a custom refund policy</p></dd>
+            
+            <dt class="align-right bold" title="group_closes"><span class="">group_closes</span></dt>
+            <dd class="rounded-all"><p>refund applies when the group closes</p></dd>
+            
+            <dt class="align-right bold" title="member_banned"><span class="">member_banned</span></dt>
+            <dd class="rounded-all"><p>refund applies when the member is banned</p></dd>
+            
+            <dt class="align-right bold" title="member_leaves"><span class="">member_leaves</span></dt>
+            <dd class="rounded-all"><p>refund applies when member leaves the group</p></dd>
+            
+            <dt class="align-right bold" title="none"><span class="">none</span></dt>
+            <dd class="rounded-all"><p>indicates there is no refund policy</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="required"><span class="">required</span></dt>
+       <dd class="rounded-all">
+        <p>true if dues are required</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="required_to"><span class="">required_to</span></dt>
+       <dd class="rounded-all">
+        <p>If the dues are required this indicates what they are required for. Currently may only be 'join'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self_payment_required"><span class="">self_payment_required</span></dt>
+       <dd class="rounded-all">
+        <p>Returns true if the authorized user is prevented from participating in the group until a payment is made</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="trial_days"><span class="">trial_days</span></dt>
+       <dd class="rounded-all">
+        <p>When present, returns the number of days the group is offering a free trial period for to new members. When not present, this indicates that the group does not offer a trial membership period</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="meta_category"><span class="">meta_category</span></dt>
+    <dd class="rounded-all">
+    <p>The meta category of the group, if the group has one</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="best_topics"><span class="">best_topics</span></dt>
+       <dd class="rounded-all">
+        <p>Represents the best topic matches for this category, returned when the "fields"
+request parameter value includes "best_topics"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic id</p></dd>
+            
+            <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+            <dd class="rounded-all"><p>Language topic originates from</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic</p></dd>
+            
+            <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+            <dd class="rounded-all"><p>The unique keyword used to identify this topic</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="category_ids"><span class="">category_ids</span></dt>
+       <dd class="rounded-all">
+        <p>List of numeric category ids associated with this topic category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic-category id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic-category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Photo representing this category</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>Unique string identifier for this category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name used for sorting</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="next_event"><span class="">next_event</span></dt>
+    <dd class="rounded-all">
+    <p>The current ongoing or next upcoming event, if one is scheduled</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="nominated_member"><span class="">nominated_member</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns if the logged in member has been nominated to take over the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="organizer"><span class="">organizer</span></dt>
+    <dd class="rounded-all">
+    <p>Group's primary organizer</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Bio of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer photo, where defined</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="past_event_count"><span class="">past_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of past events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="pending_members"><span class="">pending_members</span></dt>
+    <dd class="rounded-all">
+    <p>Number representing the count of members pending organizer approval to join. Returned only when requested in the fields request parameter and the authenticated member has permission to approve members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+    <dd class="rounded-all">
+    <p>Color combination used generate group duotone</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+       <dd class="rounded-all">
+        <p>Composite color in hexidecimal format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+       <dd class="rounded-all">
+        <p>Dark color in hexidecimal format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+       <dd class="rounded-all">
+        <p>Light color in hexidecimal format</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photos"><span class="">photos</span></dt>
+    <dd class="rounded-all">
+    <p>A small set of photos from the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_description"><span class="">plain_text_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in plain text format. Returned when then "fields" request parameter value contains "plain_text_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_no_images_description"><span class="">plain_text_no_images_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in plain text format with no images. Returned when then "fields" request parameter value contains "plain_text_no_images_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="proposed_event_count"><span class="">proposed_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of proposed events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, contains details specific to the authorized user in this Meetup Group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform, potentially "broadcast_message": the ability to broadcast messages to group members via the "announce" mailing list, "event_create": the ability to create new events, "event_draft": the ability to save new events as drafts, "role_assign": the ability to assign member roles, "edit": the ability to edit group settings, "member_approval": the ability to approve or decline member requests to join, or "subscription_upgrade": the ability to upgrade this group's subscription plan</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Member's membership dues if the group has membership dues</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="cancelled"><span class="">cancelled</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that membership dues were cancelled</p></dd>
+            
+            <dt class="align-right bold" title="exempt"><span class="">exempt</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that the member is exempt from payment.</p></dd>
+            
+            <dt class="align-right bold" title="paid_until"><span class="">paid_until</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns the time in milliseconds since the epoch that the member's next payment is due</p></dd>
+            
+            <dt class="align-right bold" title="period_status"><span class="">period_status</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns one of the following values grace paid pending unpaid</p></dd>
+            
+            <dt class="align-right bold" title="total_amount"><span class="">total_amount</span></dt>
+            <dd class="rounded-all"><p>Total amount paid</p></dd>
+            
+            <dt class="align-right bold" title="transaction_time"><span class="">transaction_time</span></dt>
+            <dd class="rounded-all"><p>Time the transaction was made in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="trial"><span class="">trial</span></dt>
+            <dd class="rounded-all"><p>If the group offers a trial membership, this indicates information for unpaid members.</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="previous_membership_dues"><span class="">previous_membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Member's membership dues history when currently not a part of group i.e Status=none if the group has membership dues</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="cancelled"><span class="">cancelled</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that membership dues were cancelled</p></dd>
+            
+            <dt class="align-right bold" title="exempt"><span class="">exempt</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that the member is exempt from payment.</p></dd>
+            
+            <dt class="align-right bold" title="paid_until"><span class="">paid_until</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns the time in milliseconds since the epoch that the member's next payment is due</p></dd>
+            
+            <dt class="align-right bold" title="period_status"><span class="">period_status</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns one of the following values grace paid pending unpaid</p></dd>
+            
+            <dt class="align-right bold" title="total_amount"><span class="">total_amount</span></dt>
+            <dd class="rounded-all"><p>Total amount paid</p></dd>
+            
+            <dt class="align-right bold" title="transaction_time"><span class="">transaction_time</span></dt>
+            <dd class="rounded-all"><p>Time the transaction was made in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="trial"><span class="">trial</span></dt>
+            <dd class="rounded-all"><p>If the group offers a trial membership, this indicates information for unpaid members.</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>Member's role in group, if any: Organizer, Assistant Organizer, Event Organizer, etc.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Indicates the authorized user's membership with this group. Value may be one of "none", "pending", "pending_payment", "active", or "blocked"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+       <dd class="rounded-all">
+        <p>Member's last visit to the group site, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, a shorted URL for the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="similar_groups"><span class="">similar_groups</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns up to 5 groups similar to this groups, best suited for the authenticated member when a single group is queried for. Note: this field is being deprecated in favor of making a separate request to /:urlname/similar_groups</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Id of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photos"><span class="">photos</span></dt>
+       <dd class="rounded-all">
+        <p>Optional fields parameter. A small set of photos from the group</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What this group calls it's members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="simple_html_description"><span class="">simple_html_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in simple HTML source format. If this group's description was saved in simple HTML format, the description field will be an HTML translation of this source. Returned when the "fields" request parameter value contains "simple_html_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State of the group, if in US or Canada</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>Status of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+    <dd class="rounded-all">
+    <p>This represents the universal timezone identifier for the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the group's topics</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+       <dd class="rounded-all">
+        <p>Language topic originates from</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+       <dd class="rounded-all">
+        <p>The unique keyword used to identify this topic</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="untranslated_city"><span class="">untranslated_city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group, not translated</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="upcoming_event_count"><span class="">upcoming_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of upcoming events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+    <dd class="rounded-all">
+    <p>Urlname used to identify the group on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Who can see this group. One of members, public or public_limited</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="welcome_message"><span class="">welcome_message</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the Group's default welcome message if the authenticated member is the organizer of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="who"><span class="">who</span></dt>
+    <dd class="rounded-all">
+    <p>What the group calls its members</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_abuse_reports.html
+++ b/test/data/_:urlname_abuse_reports.html
@@ -1,0 +1,71 @@
+
+        
+
+<div id="">
+  <h2>Report Group</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname/abuse_reports
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">reporting</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Submits a new abuse report for a target group. Abuse reports will be followed up on by our Community Support team.</p>
+  </div>
+  
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>This method requires the oauth <code>reporting</code> scope for oauth-authenticated requests</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="comments"><span class="">comments</span></dt>
+    <dd class="rounded-all"><p>An optional string of text that describes why you are submitting this report</p></dd>
+  
+    <dt class="align-right bold" title="type"><span class="param_required">type</span></dt>
+    <dd class="rounded-all"><p>A required identifier for type of abuse you are reporting. Acceptable values include dangerous, graphic_content, graphic_photo, harmful_activities, inappropriate:illegal, inappropriate:intellectual_property, inappropriate:licensed_services, inappropriate:misinformation, inappropriate:other, inappropriate:sexual_exploitation, inappropriate:sexually_explicit, inappropriate:underage, irl:hateful, irl:misrepresentation, irl:other, irl:violent, licensed_services, not_accurate, not_community, not_irl, nudity, other, poor_quality_or_spam:misinformation, poor_quality_or_spam:misleading_title, poor_quality_or_spam:no_description, poor_quality_or_spam:not_irl, poor_quality_or_spam:other, poor_quality_or_spam:spam, promotion_focus, sex, smyte_warn, transactional, violence, violent_or_hateful:hateful, violent_or_hateful:misinformation, violent_or_hateful:other, violent_or_hateful:violent</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>A successful abuse report request will result in a 202 Accepted response</p>
+  <dl>
+  
+  </dl>
+  
+  
+  <h3 id="examples" class="rounded-all">Examples</h3>
+  <p>Submit an abuse report for a group {urlname} that doesn't appear to be fostering a health community</p>
+<pre><code>curl -H "Authorization: Bearer {token}" \
+  "https://api.meetup.com/{urlname}/abuse_reports" \
+  -d "type=not_community"
+</code></pre>
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_boards.html
+++ b/test/data/_:urlname_boards.html
@@ -1,0 +1,145 @@
+
+        
+
+<div id="">
+  <h2>Discussion Boards</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/boards
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Listings of Group discussion boards</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/boards">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>The :urlname path element may be any valid group urlname or domain name</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time board was created in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="discussion_count"><span class="">discussion_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of discussions on this board</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>The group associated with this board</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric ID of group</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric ID of discussion board</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="latest_reply"><span class="">latest_reply</span></dt>
+    <dd class="rounded-all">
+    <p>The latest reply on this board</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Time reply was posted in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="member"><span class="">member</span></dt>
+       <dd class="rounded-all">
+        <p>The posting member</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Member name</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Discussion board name</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="post_count"><span class="">post_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of posts in discussions on this board</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Time board was updated in milliseconds since the epoch</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+  <h3 id="examples" class="rounded-all">Examples</h3>
+  <p>Get a list of the current <a href="http://www.meetup.com/dashing-whippets/messages/boards/">Dashing Whippet's boards</a></p>
+<pre><code>curl 'https://api.meetup.com/dashing-whippets/boards?key=API_KEY'
+</code></pre>
+<p><a href="/meetup_api/console/?path=/:urlname/boards&amp;:urlname=dashing-whippets">Try it in the console</a></p>
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_boards_:bid_discussions.html
+++ b/test/data/_:urlname_boards_:bid_discussions.html
@@ -1,0 +1,179 @@
+
+        
+
+<div id="">
+  <h2>Discussions</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/boards/:bid/discussions
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Listings of group discussions</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/boards/:bid/discussions">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>The :urlname path element may be any valid group urlname or domain name. The :bid path element may be any valid board ID for this group.</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h4 id="ordering">Ordering</h4>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold"><span class="">last_post_date</span></dt>
+    <dd class="rounded-all"><p>(default) by post date</p></dd>
+  
+    <dt class="align-right bold"><span class="">member_name</span></dt>
+    <dd class="rounded-all"><p>by posting member's name</p></dd>
+  
+    <dt class="align-right bold"><span class="">thread_reply_count</span></dt>
+    <dd class="rounded-all"><p>by the threads reply count</p></dd>
+  
+    <dt class="align-right bold"><span class="">thread_view_count</span></dt>
+    <dd class="rounded-all"><p>by the number of views a thread has</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="board"><span class="">board</span></dt>
+    <dd class="rounded-all">
+    <p>The board this discussion belongs to</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric ID of this discussion's board</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="body"><span class="">body</span></dt>
+    <dd class="rounded-all">
+    <p>The contents of the first post in this discussion</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time board was created in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric discussion ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="last_post"><span class="">last_post</span></dt>
+    <dd class="rounded-all">
+    <p>The last post made in this discussion</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Time post was made in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="member"><span class="">member</span></dt>
+       <dd class="rounded-all">
+        <p>The posting member</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Member name</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="reply_count"><span class="">reply_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of replies this discussion has</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="started_by"><span class="">started_by</span></dt>
+    <dd class="rounded-all">
+    <p>The member that started this discussion</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Member name</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="subject"><span class="">subject</span></dt>
+    <dd class="rounded-all">
+    <p>The subject of the first post in this discussion</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Time board was updated in milliseconds since the epoch</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+  <h3 id="examples" class="rounded-all">Examples</h3>
+  <p>Get a list of the current discussions going on in
+The Dashing Whippet's <a href="http://www.meetup.com/dashing-whippets/messages/boards/forum/1061014">Whippet lounge</a></p>
+<pre><code>curl 'https://api.meetup.com/dashing-whippets/boards/1061014/discussions?key=API_KEY'
+</code></pre>
+<p><a href="/meetup_api/console/?path=/:urlname/boards/:bid/discussions&amp;:urlname=dashing-whippets&amp;:bid=1061014">Try it in the console</a></p>
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_boards_:bid_discussions_:did.html
+++ b/test/data/_:urlname_boards_:bid_discussions_:did.html
@@ -1,0 +1,163 @@
+
+        
+
+<div id="">
+  <h2>Discussion Posts</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/boards/:bid/discussions/:did
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Listing Group discussion posts</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/boards/:bid/discussions/:did">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>The :urlname path element may be any valid group urlname or domain name. The :bid path element maybe any valid board ID for this group. The :did may be any valid discussion ID for this board</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="body"><span class="">body</span></dt>
+    <dd class="rounded-all">
+    <p>content of the post</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time post was created in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="discussion"><span class="">discussion</span></dt>
+    <dd class="rounded-all">
+    <p>The discussion this was posted in</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric discussion ID</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric post ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="in_reply_to"><span class="">in_reply_to</span></dt>
+    <dd class="rounded-all">
+    <p>ID of the post this was in reply to</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>The member that started this discussion</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="city"><span class="">city</span></dt>
+       <dd class="rounded-all">
+        <p>City, if provided, for the member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country, if provided, for the member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Member name</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Photo object for active member</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="thumb"><span class="">thumb</span></dt>
+            <dd class="rounded-all"><p>Thumbnail photo url</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State if in the US</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="subject"><span class="">subject</span></dt>
+    <dd class="rounded-all">
+    <p>subject of the post</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Time post was updated in milliseconds since the epoch</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_events.html
+++ b/test/data/_:urlname_events.html
@@ -1,0 +1,2849 @@
+
+        
+
+<div id="create">
+  <h2>Create Event</h2>
+  <div id="createuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname/events
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">event_management</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Creates a new Meetup group event</p>
+  </div>
+  
+  <h3 id="createparams" class="rounded-all">Request Parameters</h3>
+  <div class="createparam-notes"><p>A valid path parameter for <strong>:urlname</strong> is required.</p>
+<p>Only members of the lead team may post new Meetup events</p>
+<p>Creating an event without a <code>time</code> will result in an event with a "proposed"
+status.</p>
+<p>Event descriptions only support a subset of HTML, <code>B</code>, <code>I</code>, <code>A</code> in particular. Response bodies will include a description field that
+returns a full HTML rendering of the provided description. Links to images will be rendered in <code>IMG</code> tags, but when editing, you should omit the <code>IMG</code> tag markup.
+To get back the simplified markup, append 'simple_html_description' to the 'fields' request parameter.</p>
+<p>OAuth authenticated applications should request the <a href="/meetup_api/auth/#event_management_scope">event_management</a> OAuth scope.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="announce"><span class="">announce</span></dt>
+    <dd class="rounded-all"><p>Boolean value indicating whether or not Meetup should announce this event to group members. This defaults to false.</p></dd>
+  
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all"><p>String setting the description of the event, in simple HTML format. May not be longer than 50000 characters.</p></dd>
+  
+    <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+    <dd class="rounded-all"><p>Positive long representing event duration in milliseconds. This defaults to 10800000 (3 hours).</p></dd>
+  
+    <dt class="align-right bold" title="event_hosts"><span class="">event_hosts</span></dt>
+    <dd class="rounded-all"><p>String containing up to 5 comma-separated valid member ids for members who will be hosts of the event. This defaults to the authenticated member when self_rsvp is true or undefined.</p></dd>
+  
+    <dt class="align-right bold" title="featured_photo_id"><span class="">featured_photo_id</span></dt>
+    <dd class="rounded-all"><p>Positive integer representing a numeric identifier for a photo, which must be one associated with this group. When undefined or 0, no photo is set.</p></dd>
+  
+    <dt class="align-right bold" title="fee.accepts"><span class="">fee.accepts</span></dt>
+    <dd class="rounded-all"><p>String representing the payment method for the event fee if a fee is charged for the event. May be one of: stripe,wepay,paypal,none,cash</p></dd>
+  
+    <dt class="align-right bold" title="fee.amount"><span class="">fee.amount</span></dt>
+    <dd class="rounded-all"><p>Positive decimal representing the amount of the event fee if a fee is charged for the event. If the group is in the United States, this may not exceed 4999 (for any currency). Otherwise, this may not exceed 1000000 (for any currency). If the event fee is charged with WePay, this must be at least 1.0 USD</p></dd>
+  
+    <dt class="align-right bold" title="fee.currency"><span class="">fee.currency</span></dt>
+    <dd class="rounded-all"><p>String representing the currency for the event fee if a fee is charged for the event. May be one of: AUD,BRL,CAD,CHF,EUR,GBP,INR,JPY,KRW,PLN,RUB,THB,TRY,USD</p></dd>
+  
+    <dt class="align-right bold" title="fee.refund_policy"><span class="">fee.refund_policy</span></dt>
+    <dd class="rounded-all"><p>String setting the refund policy if the event has a fee. May not be longer than 250 characters.</p></dd>
+  
+    <dt class="align-right bold" title="guest_limit"><span class="">guest_limit</span></dt>
+    <dd class="rounded-all"><p>Positive integer representing the number of guests that members may include in their RSVP, 0 inclusive. This defaults to 2.</p></dd>
+  
+    <dt class="align-right bold" title="how_to_find_us"><span class="">how_to_find_us</span></dt>
+    <dd class="rounded-all"><p>String setting the description for the location of the host(s) at the event venue.  * For <strong>online events</strong> this field is used for the <strong>event's url</strong>.</p></dd>
+  
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all"><p>Float representing adjusted venue latitude. This can only be set if lon is included as well.</p></dd>
+  
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all"><p>Float representing adjusted venue longitude. This can only be set if lat is included as well.</p></dd>
+  
+    <dt class="align-right bold" title="name"><span class="param_required">name</span></dt>
+    <dd class="rounded-all"><p>String setting the name of the event. Must be at least 1 character and may not be longer than 80 characters.</p></dd>
+  
+    <dt class="align-right bold" title="publish_status"><span class="">publish_status</span></dt>
+    <dd class="rounded-all"><p>String indicating whether an event will be published to the group or as a draft visible only to the leadership team. May be one of "draft" or "published". This defaults to "published".</p></dd>
+  
+    <dt class="align-right bold" title="question"><span class="">question</span></dt>
+    <dd class="rounded-all"><p>String setting the RSVP survey question for the event. May not be longer than 250 characters.</p></dd>
+  
+    <dt class="align-right bold" title="rsvp_close_time"><span class="">rsvp_close_time</span></dt>
+    <dd class="rounded-all"><p>Positive long representing the time before which members will be allowed to RSVP to the event in milliseconds since the epoch. This can only be set if there is a start time for the event. This defaults to no RSVP close time restriction.</p></dd>
+  
+    <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+    <dd class="rounded-all"><p>Positive integer representing total number of RSVP slots available for the event. When undefined or defined as 0, there will be no set limit.</p></dd>
+  
+    <dt class="align-right bold" title="rsvp_open_time"><span class="">rsvp_open_time</span></dt>
+    <dd class="rounded-all"><p>Positive long representing the time after which members will be allowed to RSVP to the event in milliseconds since the epoch. This can only be set if there is a start time for the event. This defaults to no RSVP open time restriction.</p></dd>
+  
+    <dt class="align-right bold" title="self_rsvp"><span class="">self_rsvp</span></dt>
+    <dd class="rounded-all"><p>Boolean value indicating whether the authenticated member will be RSVP'd to the event upon creation. This defaults to true.</p></dd>
+  
+    <dt class="align-right bold" title="time"><span class="">time</span></dt>
+    <dd class="rounded-all"><p>Positive long representing event start time in milliseconds since the epoch.</p></dd>
+  
+    <dt class="align-right bold" title="venue_id"><span class="">venue_id</span></dt>
+    <dd class="rounded-all"><p>Positive integer representing a numeric identifier for a venue. <strong>For online events use the string alias 'online'</strong>.</p></dd>
+  
+    <dt class="align-right bold" title="venue_visibility"><span class="">venue_visibility</span></dt>
+    <dd class="rounded-all"><p>String indicating whether the event venue and host location description will be visible to non-members of the hosting group. May be one of "public" or "members". This defaults to "public".</p></dd>
+  
+  </dl>
+  
+  <h3 id="createresponse" class="rounded-all">Response</h3>
+  <p>A successful request will return a 201 response with a body containing the new event information.</p>
+<p>An HTTP Location header will also be set containing the URL to fetch future updates to the event information</p>
+  <dl>
+   
+    <dt class="align-right bold" title="attendance_count"><span class="">attendance_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of all members marked as attended, yes RSVPs that were not changed by attendance and their guests</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="attendance_sample"><span class="">attendance_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection of members marked as attended and yes RSVPs that were not changed by attendance</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="attendee_sample"><span class="">attendee_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection of attendance records of members marked as attended and yes RSVPs that were not changed by attendance. For upcoming events, this represents collection of yes RSVPs</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="comment_count"><span class="">comment_count</span></dt>
+    <dd class="rounded-all">
+    <p>An aggregate count of all comments and replies for a given event, returned when fields request parameter value includes 'comment_count'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Creation time of the event, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+    <dd class="rounded-all">
+    <p>Is event date matches the series pattern</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the event in HTML. Email addresses and phone numbers will be masked for non-members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description_images"><span class="">description_images</span></dt>
+    <dd class="rounded-all">
+    <p>A list of image urls included in the event description.  returned when "fields" request parameter value contains "description_images, only supported for GET /event/:id currently"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+    <dd class="rounded-all">
+    <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="event_hosts"><span class="">event_hosts</span></dt>
+    <dd class="rounded-all">
+    <p>List of members hosting the event, returned when fields request parameter value includes 'event_hosts'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="host_count"><span class="">host_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of times member hosted for group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="intro"><span class="">intro</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's introduction</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_date"><span class="">join_date</span></dt>
+       <dd class="rounded-all">
+        <p>Group join date in milliseconds since epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's name</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo if one exists</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="featured"><span class="">featured</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean indicator of whether or not a given event is featured, returned when fields request parameter value includes 'featured'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="featured_photo"><span class="">featured_photo</span></dt>
+    <dd class="rounded-all">
+    <p>A featured photo for this event, returned when the 'fields' request paramater includes 'featured_photo'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+    <dd class="rounded-all">
+    <p>Ticketing fee information for events that support payments</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+       <dd class="rounded-all">
+        <p>Amount of the fee</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+       <dd class="rounded-all">
+        <p>Currency accepted for fee</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="description"><span class="">description</span></dt>
+       <dd class="rounded-all">
+        <p>Fee description, typically "per-person"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="label"><span class="">label</span></dt>
+       <dd class="rounded-all">
+        <p>Label for fee, typically "Price"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="required"><span class="">required</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean flag indicating if this fee is required to RSVP</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee_options"><span class="">fee_options</span></dt>
+    <dd class="rounded-all">
+    <p>Payment options for event ticketing, returned when the 'fields' request parameter value includes 'fee_options'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currencies"><span class="">currencies</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable currencies for the payment method specified by type</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="code"><span class="">code</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="default"><span class="">default</span></dt>
+            <dd class="rounded-all"><p>A boolean set to true if the currency is the group's default currency, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="is_setup"><span class="">is_setup</span></dt>
+       <dd class="rounded-all">
+        <p>A boolean set to true if the payment method specified by 'type' is set up for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="setup_link"><span class="">setup_link</span></dt>
+       <dd class="rounded-all">
+        <p>The URL for setting up the payment method specified by 'type'. This is returned if the payment method specified by 'type' is not set up for the group and the member has the permission to set it up</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of Set(stripe, wepay, paypal, none, cash)</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>Information about group hosting the event</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="category"><span class="">category</span></dt>
+       <dd class="rounded-all">
+        <p>Category group belongs to, returned when fields request parameter value includes 'group_category'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric category id</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the category</p></dd>
+            
+            <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+            <dd class="rounded-all"><p>String identifier of the category</p></dd>
+            
+            <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+            <dd class="rounded-all"><p>Name used for sorting</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric identifier for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_info"><span class="">join_info</span></dt>
+       <dd class="rounded-all">
+        <p>Lists any questions requested when joining and required fields. Returned with "fields" request parameter value includes "group_join_info"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="photo_req"><span class="">photo_req</span></dt>
+            <dd class="rounded-all"><p>true if required, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="questions"><span class="">questions</span></dt>
+            <dd class="rounded-all"><p>List of profile questions organizer would like new members to answer prior to joining</p></dd>
+            
+            <dt class="align-right bold" title="questions_req"><span class="">questions_req</span></dt>
+            <dd class="rounded-all"><p>true if required, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo, returned when fields request parameter value includes 'group_key_photo'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate group latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate group longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Membership dues information associated with hosting group, returned when fields request parameter value includes 'group_membership_dues'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency in which the fee is declared</p></dd>
+            
+            <dt class="align-right bold" title="dues_links"><span class="">dues_links</span></dt>
+            <dd class="rounded-all"><p>Links to dues management and checkout pages.</p></dd>
+            
+            <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+            <dd class="rounded-all"><p>Numeric fee value</p></dd>
+            
+            <dt class="align-right bold" title="fee_desc"><span class="">fee_desc</span></dt>
+            <dd class="rounded-all"><p>The interval at which dues must be paid. Possible values may include: "month", "year", "day", or "every other day"</p></dd>
+            
+            <dt class="align-right bold" title="methods"><span class="">methods</span></dt>
+            <dd class="rounded-all"><p>Methods of payments</p></dd>
+            
+            <dt class="align-right bold" title="reasons"><span class="">reasons</span></dt>
+            <dd class="rounded-all"><p>Array of reasons containing one or more of the following values compensate_organizer, cover_costs, encourage_engagement, improve_meetups, other, provide_supplies, reserve_fund</p></dd>
+            
+            <dt class="align-right bold" title="reasons_other"><span class="">reasons_other</span></dt>
+            <dd class="rounded-all"><p>An additional reason if specified.</p></dd>
+            
+            <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+            <dd class="rounded-all"><p>Conditions for refunds</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>true if dues are required</p></dd>
+            
+            <dt class="align-right bold" title="required_to"><span class="">required_to</span></dt>
+            <dd class="rounded-all"><p>If the dues are required this indicates what they are required for. Currently may only be 'join'</p></dd>
+            
+            <dt class="align-right bold" title="self_payment_required"><span class="">self_payment_required</span></dt>
+            <dd class="rounded-all"><p>Returns true if the authorized user is prevented from participating in the group until a payment is made</p></dd>
+            
+            <dt class="align-right bold" title="trial_days"><span class="">trial_days</span></dt>
+            <dd class="rounded-all"><p>When present, returns the number of days the group is offering a free trial period for to new members. When not present, this indicates that the group does not offer a trial membership period</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="meta_category"><span class="">meta_category</span></dt>
+       <dd class="rounded-all">
+        <p>The meta category of the group, if the group has one, returned when fields request parameter value inclues 'meta_category'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="best_topics"><span class="">best_topics</span></dt>
+            <dd class="rounded-all"><p>Represents the best topic matches for this category, returned when the "fields"
+request parameter value includes "best_topics"</p></dd>
+            
+            <dt class="align-right bold" title="category_ids"><span class="">category_ids</span></dt>
+            <dd class="rounded-all"><p>List of numeric category ids associated with this topic category</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic-category id</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic-category</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Photo representing this category</p></dd>
+            
+            <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+            <dd class="rounded-all"><p>Unique string identifier for this category</p></dd>
+            
+            <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+            <dd class="rounded-all"><p>Name used for sorting</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count"><span class="">past_event_count</span></dt>
+       <dd class="rounded-all">
+        <p>The number of past events belonging to the group, returned when "fields" includes "group_past_event_count"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Photo associated with group, returned when fields request parameter value includes 'group_photo'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used to generate group duotone, returned when fields request parameter value includes 'group_photo_gradient'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="pro_network"><span class="">pro_network</span></dt>
+       <dd class="rounded-all">
+        <p>Information on group's Pro organization, returned when "fields" request parameter value includes "group_pro_network"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="region"><span class="">region</span></dt>
+       <dd class="rounded-all">
+        <p>Language and region of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self"><span class="">self</span></dt>
+       <dd class="rounded-all">
+        <p>Information pertaining to the authenticated member with respect to the group, returned when fields request parameter value includes 'group_self_profile', 'group_self_actions', 'group_self_membership_dues', or 'group_self_status'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+            <dd class="rounded-all"><p>list of actions the authenticated member may perform, potentially "event_create": the ability to create new events, "event_draft": the ability to save new events as drafts, "role_assign": the ability to assign member roles, "edit": the ability to edit group settings, "member_approval": the ability to approve or decline member requests to join, or "subscription_upgrade": the ability to upgrade this group's subscription plan</p></dd>
+            
+            <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+            <dd class="rounded-all"><p>Membership dues information associated with hosting group, returned when "fields" request parameter value includes "group_membership_dues" and group has dues</p></dd>
+            
+            <dt class="align-right bold" title="profile"><span class="">profile</span></dt>
+            <dd class="rounded-all"><p>Profile of the authenticated member</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Indicates the authorized user's membership with this group.</p>
+<p>Value may be one of "none", "pending", "pending_payment", "active", or "blocked"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+       <dd class="rounded-all">
+        <p>Timezone of group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>Topics related to the group, returned when fields request parameter value includes 'group_topics'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic id</p></dd>
+            
+            <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+            <dd class="rounded-all"><p>Language topic originates from</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic</p></dd>
+            
+            <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+            <dd class="rounded-all"><p>The unique keyword used to identify this topic</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric urlname identifier for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+       <dd class="rounded-all">
+        <p>Group visibility, returned when fields request parameter value includes 'group_visibility'. Value may be "public", "public_limited", or "members".</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="how_to_find_us"><span class="">how_to_find_us</span></dt>
+    <dd class="rounded-all">
+    <p>Additional information on how to find members at a venue when provided by an organizer, returned when fields request parameter value includes 'how_to_find_us'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>A unique alphanumeric identifier for event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+    <dd class="rounded-all">
+    <p>Is event happening online</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to event on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+    <dd class="rounded-all">
+    <p>The local date of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+    <dd class="rounded-all">
+    <p>The local time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="manual_attendance_count"><span class="">manual_attendance_count</span></dt>
+    <dd class="rounded-all">
+    <p>Manually entered total attendee headcount, if any exists</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of the event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+    <dd class="rounded-all">
+    <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+    <dd class="rounded-all">
+    <p>Information about photo uploads for this event, returned when fields request parameter value includes 'photo_album'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="event"><span class="">event</span></dt>
+       <dd class="rounded-all">
+        <p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric event ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of event</p></dd>
+            
+            <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of no RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="time"><span class="">time</span></dt>
+            <dd class="rounded-all"><p>UTC start time of the event, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+            <dd class="rounded-all"><p>The local offset from UTC time, in milliseconds</p></dd>
+            
+            <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+            <dd class="rounded-all"><p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of yes RSVPs</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for photo album</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of photos uploaded</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection of photos uploaded for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Album title</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_description"><span class="">plain_text_description</span></dt>
+    <dd class="rounded-all">
+    <p>Plain text version of the event description. Email addresses and photo numbers will be masked for non-members. Returned when "fields" request parameter value contains "plain_text_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_no_images_description"><span class="">plain_text_no_images_description</span></dt>
+    <dd class="rounded-all">
+    <p>Plain text version of the event description without images. Email addresses and photo numbers will be masked for non-members. Returned when "fields" request parameter value contains "plain_text_no_images_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+    <dd class="rounded-all">
+    <p>The number of "yes" RSVPS an event has capacity for</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_rules"><span class="">rsvp_rules</span></dt>
+    <dd class="rounded-all">
+    <p>Information about conditions that allow for member RSVPs, returned when fields request parameter value include 'rsvp_rules'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="close_time"><span class="">close_time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC time that RSVPs will no longer be accepted, though organizers may close RSVPs earlier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="closed"><span class="">closed</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean value indicating whether or not RSVPing was explicitly closed for the event.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="guest_limit"><span class="">guest_limit</span></dt>
+       <dd class="rounded-all">
+        <p>Number of guests members may include in their RSVP, 0 or more</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="open_time"><span class="">open_time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC time that members may begin to RSVP</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+       <dd class="rounded-all">
+        <p>The organizer-defined terms for refunds. If this is defined, you must provide the authenticated member a way to access this information before they can RSVP. They will need to agree to these terms before they RSVP</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="days"><span class="">days</span></dt>
+            <dd class="rounded-all"><p>if member_cancellation is present, it's relative to this many days before the event</p></dd>
+            
+            <dt class="align-right bold" title="notes"><span class="">notes</span></dt>
+            <dd class="rounded-all"><p>additional refund policy notes</p></dd>
+            
+            <dt class="align-right bold" title="policies"><span class="">policies</span></dt>
+            <dd class="rounded-all"><p>list of one or more of the following. 'no_refunds' if the organizer will not issue refunds', 'member_cancellation' if the organizer offers a refund for member cancellation, 'event_cancellation' if the organizer offers a refund if the event is canceled, 'event_rescheduled' if the organizer offers a refund when the event is rescheduled</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlisting"><span class="">waitlisting</span></dt>
+       <dd class="rounded-all">
+        <p>Wait list handling when RSVP limit is reached. Value may be one of 'auto', 'manual' or 'off'</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection RSVPs for members attending this event, returned when fields request parameter value includes 'rsvp_sample'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the RSVP, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="member"><span class="">member</span></dt>
+       <dd class="rounded-all">
+        <p>Member who RSVP'd</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+            <dd class="rounded-all"><p>Intro of member</p></dd>
+            
+            <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+            <dd class="rounded-all"><p>Member's context within the event. Only returned in the context of an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric member ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of member</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="self"><span class="">self</span></dt>
+            <dd class="rounded-all"><p>Represents the authenticated member's relation to member.
+Returned with the "fields" request parameter includes "self" and
+the target member is not the authenticated member</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time of the RSVP, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvpable"><span class="">rsvpable</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean value indicating whether or not the authenticated member can RSVP or join the waitlist when the event is full.
+Returned when the "fields" request parameter value
+includes "rsvpable"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvpable_after_join"><span class="">rsvpable_after_join</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean value indicating whether or not the authenticated member can RSVP
+after joining the hosting group.
+Returned when the "fields" request parameter
+includes "rsvpable_after_join"
+and the authenticated member is <em>not</em> a member of the
+group hosting this event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="saved"><span class="">saved</span></dt>
+    <dd class="rounded-all">
+    <p>Whether the authorized member has saved the event, returned when fields request parameter value includes 'saved'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>represents details particular to the authorized user, only present if requested and authenticated member is a member of the hosting group, returned when fields request parameter value includes 'self'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform, potentially one or more of the following</p>
+<p>"announce" to announce the event to the group's members</p>
+<p>"attendance" to view or take attendance for the event</p>
+<p>"copy" the ability to copy an event</p>
+<p>"comment" the ability to post a comment or reply</p>
+<p>"payments" the ability to mark members as paid if the event is ticketed</p>
+<p>"publish" to publish a draft event</p>
+<p>"edit" to edit the event information</p>
+<p>"edit_hosts" to edit the hosts for the event</p>
+<p>"email_attendees" the ability to email event attendees</p>
+<p>"delete" to delete the event</p>
+<p>"rsvp" to RSVP yes or no to the event</p>
+<p>"wait" to get on the waiting list (using the same RSVP methods).</p>
+<p>"dues" if an organizer requires membership dues to RSVP and the authorized
+ member has not paid theirs</p>
+<p>"upload_photo" the ability to upload a photo for the event</p>
+<p>"cancel" the ability to cancel the event</p>
+<p>"close" the ability to close the RSVPs for the event</p>
+<p>"open" the ability to open the RSVPs for the event</p>
+<p>"invite" the ability to invite someone for the event</p>
+<p>"download_attendees" the ability to download the attendees list for the event</p>
+<p>"take_attendance" the ability to take attendance for the event</p>
+<p>"delete_cancelled" the ability to delete the event if it is cancelled</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="pay_status"><span class="">pay_status</span></dt>
+       <dd class="rounded-all">
+        <p>The authenticated member's payment status. This may be one of 'none', 'paid', 'partially_paid', 'payment_pending', 'echeck_pending', 'refund_pending', 'partially_refunded', 'refunded'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The authenticated member's role in within the group, if any. This may be one of: Organizer, Assistant Organizer, Event Organizer, etc.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp"><span class="">rsvp</span></dt>
+       <dd class="rounded-all">
+        <p>Member's RSVP, if any</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+            <dd class="rounded-all"><p>List of answers to event survey questions asked when the member RSVP'd in the order asked, only available to organizers and assistant organizers</p></dd>
+            
+            <dt class="align-right bold" title="guests"><span class="">guests</span></dt>
+            <dd class="rounded-all"><p>Number of guests the RSVP'd member will be bringing</p></dd>
+            
+            <dt class="align-right bold" title="response"><span class="">response</span></dt>
+            <dd class="rounded-all"><p>May be "yes" or "no".</p>
+<p>In cases where an event is over capacity and the member has shown an intent to attend,
+response may be "waitlist" if the event has a waitlist.</p>
+<p>In cases of ticketed events, this may be "yes_pending_payment"
+for a "yes" response for a ticketed event with an unprocessed payment</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="series"><span class="">series</span></dt>
+    <dd class="rounded-all">
+    <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="description"><span class="">description</span></dt>
+       <dd class="rounded-all">
+        <p>Human displayable description of how often events in this series occur</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+       <dd class="rounded-all">
+        <p>Date when this series ends/ended, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the series</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+       <dd class="rounded-all">
+        <p>Returned for events that are part of a monthly recurring series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="day_of_week"><span class="">day_of_week</span></dt>
+            <dd class="rounded-all"><p>Integer value between 1-7 (Monday-Sunday) for the day of week the recurrence occurs upon</p></dd>
+            
+            <dt class="align-right bold" title="interval"><span class="">interval</span></dt>
+            <dd class="rounded-all"><p>Integer number of months between each recurrence</p></dd>
+            
+            <dt class="align-right bold" title="week_of_month"><span class="">week_of_month</span></dt>
+            <dd class="rounded-all"><p>Integer value between 1-5 representing the week number on which the event recurs. A value of 5 indicates the event recurs on the last week of every month</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+       <dd class="rounded-all">
+        <p>Date when this series begins/began, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the template event of the series</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+       <dd class="rounded-all">
+        <p>Returned for events that are part of a weekly recurring series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="days_of_week"><span class="">days_of_week</span></dt>
+            <dd class="rounded-all"><p>List of integers 1-7 (Monday-Sunday) of days of week recurrence occurs upon</p></dd>
+            
+            <dt class="align-right bold" title="interval"><span class="">interval</span></dt>
+            <dd class="rounded-all"><p>Integer number of weeks between each recurrence</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>A shortened link for the event on meetup.com, returned when fields request parameter value includes "short_link"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="simple_html_description"><span class="">simple_html_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the event, in simple HTML source format. If this event's description was saved in simple HTML format, the description field will be an HTML translation of this source. Returned when the "fields"' request parameter contains "simple_html_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>"cancelled", "upcoming", "past", "proposed", "suggested", or "draft"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+    <dd class="rounded-all">
+    <p>List of organizer-defined survey questions intended to be asked of RSVPing members. Returned when the "fields"' request parameter contains "answers"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric question identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="question"><span class="">question</span></dt>
+       <dd class="rounded-all">
+        <p>Question text</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="time"><span class="">time</span></dt>
+    <dd class="rounded-all">
+    <p>UTC start time of the event, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Last modified time for the event in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The local offset from UTC time, in milliseconds</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+    <dd class="rounded-all">
+    <p>The event venue, present only if selected and not hidden by an organizer</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+       <dd class="rounded-all">
+        <p>Line 1 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+       <dd class="rounded-all">
+        <p>Line 2 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+       <dd class="rounded-all">
+        <p>Line 3 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="city"><span class="">city</span></dt>
+       <dd class="rounded-all">
+        <p>City of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country code of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric venue id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+       <dd class="rounded-all">
+        <p>The localized name of the venue's country</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Venue name</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+       <dd class="rounded-all">
+        <p>Phone number of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+       <dd class="rounded-all">
+        <p>true if the editor of the event altered the original venues pin location, false otherwise</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State of venue where available</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+       <dd class="rounded-all">
+        <p>ZIP code if, venue is in US or Canada</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="venue_visibility"><span class="">venue_visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Represents who can see the venue with a potential value of "members" or "public", returned when fields request parameter value includes "venue_visibility" and the authenticated member is a member of the group hosting the event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Event visibility: "public", "public_limited", or "members". Events in private groups that do not expose limited information are visible only to that group's members and should not be made public.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of members on the waitlist, if one exists</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="web_actions"><span class="">web_actions</span></dt>
+    <dd class="rounded-all">
+    <p>Set of "Invite" and google/yahoo/ical/outlook "Add to calendar" web actions</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="why"><span class="">why</span></dt>
+    <dd class="rounded-all">
+    <p>We should do this because...</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of yes RSVPs including guests</p>
+    
+    </dd>
+  
+  </dl>
+  
+  <h4 id="createerrors" class="rounded-all">Errors</h4>
+  <dl>
+  
+    <dt class="align-right bold"><span class="">announce_error</span></dt>
+    <dd><p>Error announcing event</p></dd>
+  
+    <dt class="align-right bold"><span class="">description_error</span></dt>
+    <dd><p>Sorry, your Meetup description is too long</p></dd>
+  
+    <dt class="align-right bold"><span class="">duration_error</span></dt>
+    <dd><p>This event duration is invalid</p></dd>
+  
+    <dt class="align-right bold"><span class="">event_error</span></dt>
+    <dd><p>The id provided does not correspond to an event that can be edited</p></dd>
+  
+    <dt class="align-right bold"><span class="">event_hosts_error</span></dt>
+    <dd><p>One or more of the members provided are not active members of this group</p></dd>
+  
+    <dt class="align-right bold"><span class="">featured_photo_id_error</span></dt>
+    <dd><p>Something is wrong with the featured photo provided</p></dd>
+  
+    <dt class="align-right bold"><span class="">fee.amount_error</span></dt>
+    <dd><p>If the group is in the United States, the fee amount may not exceed 4999. Otherwise, the amount may not exceed 1000000</p></dd>
+  
+    <dt class="align-right bold"><span class="">fee.refund_policy_error</span></dt>
+    <dd><p>The fee refund policy may not exceed 250</p></dd>
+  
+    <dt class="align-right bold"><span class="">guest_limit_error</span></dt>
+    <dd><p>The guest limit is invalid</p></dd>
+  
+    <dt class="align-right bold"><span class="">how_to_find_us_error</span></dt>
+    <dd><p>Your "How to find us" description is too long</p></dd>
+  
+    <dt class="align-right bold"><span class="">lat_error</span></dt>
+    <dd><p>Your location is invalid</p></dd>
+  
+    <dt class="align-right bold"><span class="">local_date_error</span></dt>
+    <dd><p>If specifying a local date, your Meetup must also specify a local time</p></dd>
+  
+    <dt class="align-right bold"><span class="">local_time_error</span></dt>
+    <dd><p>If specifying a local time, your Meetup must also specify a local date</p></dd>
+  
+    <dt class="align-right bold"><span class="">name_error</span></dt>
+    <dd><p>A title is required to post your Meetup</p></dd>
+  
+    <dt class="align-right bold"><span class="">publish_status_error</span></dt>
+    <dd><p>You cannot publish a draft meetup with a start time in the past</p></dd>
+  
+    <dt class="align-right bold"><span class="">question_error</span></dt>
+    <dd><p>Something is not right with the RSVP question field</p></dd>
+  
+    <dt class="align-right bold"><span class="">rsvp_close_time_error</span></dt>
+    <dd><p>Your Meetup needs to have a start time before you can set an RSVP close time</p></dd>
+  
+    <dt class="align-right bold"><span class="">rsvp_limit_error</span></dt>
+    <dd><p>The RSVP limit is invalid</p></dd>
+  
+    <dt class="align-right bold"><span class="">rsvp_open_time_error</span></dt>
+    <dd><p>Please make sure your RSVPs are open before they close</p></dd>
+  
+    <dt class="align-right bold"><span class="">series.apply_to_error</span></dt>
+    <dd><p>A parameter was specified that is unsupported when editing a series</p></dd>
+  
+    <dt class="align-right bold"><span class="">series.weekly.days_of_week_error</span></dt>
+    <dd><p>This value must be one or more numbers between 1 and 7 separated by commas - representative of Monday through Sunday</p></dd>
+  
+    <dt class="align-right bold"><span class="">series_error</span></dt>
+    <dd><p>Something is wrong with the series</p></dd>
+  
+    <dt class="align-right bold"><span class="">time_error</span></dt>
+    <dd><p>There is a problem with the Meetup start time</p></dd>
+  
+    <dt class="align-right bold"><span class="">venue_id_error</span></dt>
+    <dd><p>Your location does not exist or can't be found</p></dd>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="list">
+  <h2>Group Events</h2>
+  <div id="listuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/events
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Gets a listing of all Meetup Events hosted by a target group, in ascending order by default</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/events">Try it in the console</a></p>
+  <h3 id="listparams" class="rounded-all">Request Parameters</h3>
+  <div class="listparam-notes"><p>All parameters are optional.</p>
+<p>This endpoint uses HTTP <a href="/meetup_api/docs/#v3_json">Link header based pagination</a></p>
+<p>The default order is ascending. To return the list in descending order, send desc=true in requests.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="desc"><span class="">desc</span></dt>
+    <dd class="rounded-all"><p>When true, sorts results in descending order. Defaults to false</p></dd>
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>Comma-delimited list of optional field names to append to the response.</p></dd>
+  
+    <dt class="align-right bold" title="has_ended"><span class="">has_ended</span></dt>
+    <dd class="rounded-all"><p>An optional boolean which returns events which have ended when true. When false, returns events which are ongoing or upcoming. Defaults to empty/none.
+If requested with no_earlier_than, no_later_than, and/or scroll, it returns the subset of events that would be returned when a request
+is made with those parameters, that also meets the criterion specified by has_ended.
+i.e. if scroll requests events that start in the future and has_ended is true, then returns an empty result set;
+if scroll requests events that start in the past and common.events.HasEnded is false, then returns events that started before now but have not yet ended.</p></dd>
+  
+    <dt class="align-right bold" title="no_earlier_than"><span class="">no_earlier_than</span></dt>
+    <dd class="rounded-all"><p>An optional timestamp that represents a lower time bound (inclusive) for the start time of events in the local time of the group.
+If provided, it must be a string in ISO 8601 format without a time zone specified, i.e. 2018-06-01T00:00:00.000.
+If provided, the API will not return events with a start time earlier than the time specified by this parameter.
+If both this parameter and scroll are present, such that scroll does not have a type of ctime and it requests events
+that start after the specified scroll time,
+then the API returns events after whichever of scroll and no_earlier_than comes later.</p></dd>
+  
+    <dt class="align-right bold" title="no_later_than"><span class="">no_later_than</span></dt>
+    <dd class="rounded-all"><p>An optional timestamp that represents an upper time bound (exclusive) for the start time of events in the local time of the group.
+If provided, it must be a string in ISO 8601 format without a time zone specified, i.e. 2018-06-01T00:00:00.000.
+If provided, the API will not return events with a start time later than or equal to the time specified by this parameter.
+If both this parameter and scroll are present, such that scroll does not have a type of ctime and it
+requests events before the specified scroll time,
+then the API returns events before whichever of scroll and no_later_than comes earlier.</p></dd>
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>Number of results to return in a page. Must be an integer greater than or equal to 1. Defaults to 200</p></dd>
+  
+    <dt class="align-right bold" title="scroll"><span class="">scroll</span></dt>
+    <dd class="rounded-all"><p>A string representing an alias for a point on a timeline.</p>
+<p><strong>recent_past</strong>: Scroll to the last past Meetup Event. If there are no recently events in the past,
+this defaults to <strong>next_upcoming</strong>. Unless otherwise specified, this will apply a 'status' filter
+of "upcoming" and "past".</p>
+<p><strong>next_upcoming</strong>: Scroll to the next upcoming Meetup event. Unless otherwise specified, this will apply a 'status'
+filter of "upcoming" and "past"</p>
+<p><strong>future_or_past</strong>: Scroll to the next ongoing or upcoming Meetup event. If there are no ongoing or upcoming events,
+this defaults to returning past events. Unless otherwise specified, this will apply a 'status'
+filter of "upcoming" and "past".</p>
+<p>If both the scroll parameter and no_earlier_than are present and scroll requests events before no_earlier_than,
+then this parameter is disregarded and the API returns events starting at or starting after no_earlier_than.</p>
+<p>If both the scroll parameter and no_later_than are present and scroll requests events after no_later_than,
+then this parameter is disregarded and the API returns events starting before no_later_than.</p></dd>
+  
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of event statuses. Valid values are: "cancelled", "draft", "past", "proposed", "suggested", or "upcoming".
+Events with "draft" status may be accessed by the group's organizers; guest event hosts may access only the drafts of events they host.
+The "draft" status may not be requested with other status values.
+The status value defaults to "upcoming" unless a scroll parameter is provided.
+If more than one status is requested, events with "proposed" status are returned last.</p></dd>
+  
+  </dl>
+  
+  <h3 id="listresponse" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="attendance_count"><span class="">attendance_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of all members marked as attended, yes RSVPs that were not changed by attendance and their guests</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="attendance_sample"><span class="">attendance_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection of members marked as attended and yes RSVPs that were not changed by attendance</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="attendee_sample"><span class="">attendee_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection of attendance records of members marked as attended and yes RSVPs that were not changed by attendance. For upcoming events, this represents collection of yes RSVPs</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="comment_count"><span class="">comment_count</span></dt>
+    <dd class="rounded-all">
+    <p>An aggregate count of all comments and replies for a given event, returned when fields request parameter value includes 'comment_count'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Creation time of the event, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+    <dd class="rounded-all">
+    <p>Is event date matches the series pattern</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the event in HTML. Email addresses and phone numbers will be masked for non-members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description_images"><span class="">description_images</span></dt>
+    <dd class="rounded-all">
+    <p>A list of image urls included in the event description.  returned when "fields" request parameter value contains "description_images, only supported for GET /event/:id currently"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+    <dd class="rounded-all">
+    <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="event_hosts"><span class="">event_hosts</span></dt>
+    <dd class="rounded-all">
+    <p>List of members hosting the event, returned when fields request parameter value includes 'event_hosts'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="host_count"><span class="">host_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of times member hosted for group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="intro"><span class="">intro</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's introduction</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_date"><span class="">join_date</span></dt>
+       <dd class="rounded-all">
+        <p>Group join date in milliseconds since epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's name</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo if one exists</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="featured"><span class="">featured</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean indicator of whether or not a given event is featured, returned when fields request parameter value includes 'featured'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="featured_photo"><span class="">featured_photo</span></dt>
+    <dd class="rounded-all">
+    <p>A featured photo for this event, returned when the 'fields' request paramater includes 'featured_photo'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+    <dd class="rounded-all">
+    <p>Ticketing fee information for events that support payments</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+       <dd class="rounded-all">
+        <p>Amount of the fee</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+       <dd class="rounded-all">
+        <p>Currency accepted for fee</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="description"><span class="">description</span></dt>
+       <dd class="rounded-all">
+        <p>Fee description, typically "per-person"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="label"><span class="">label</span></dt>
+       <dd class="rounded-all">
+        <p>Label for fee, typically "Price"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="required"><span class="">required</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean flag indicating if this fee is required to RSVP</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee_options"><span class="">fee_options</span></dt>
+    <dd class="rounded-all">
+    <p>Payment options for event ticketing, returned when the 'fields' request parameter value includes 'fee_options'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currencies"><span class="">currencies</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable currencies for the payment method specified by type</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="code"><span class="">code</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="default"><span class="">default</span></dt>
+            <dd class="rounded-all"><p>A boolean set to true if the currency is the group's default currency, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="is_setup"><span class="">is_setup</span></dt>
+       <dd class="rounded-all">
+        <p>A boolean set to true if the payment method specified by 'type' is set up for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="setup_link"><span class="">setup_link</span></dt>
+       <dd class="rounded-all">
+        <p>The URL for setting up the payment method specified by 'type'. This is returned if the payment method specified by 'type' is not set up for the group and the member has the permission to set it up</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of Set(stripe, wepay, paypal, none, cash)</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>Information about group hosting the event</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="category"><span class="">category</span></dt>
+       <dd class="rounded-all">
+        <p>Category group belongs to, returned when fields request parameter value includes 'group_category'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric category id</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the category</p></dd>
+            
+            <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+            <dd class="rounded-all"><p>String identifier of the category</p></dd>
+            
+            <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+            <dd class="rounded-all"><p>Name used for sorting</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric identifier for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_info"><span class="">join_info</span></dt>
+       <dd class="rounded-all">
+        <p>Lists any questions requested when joining and required fields. Returned with "fields" request parameter value includes "group_join_info"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="photo_req"><span class="">photo_req</span></dt>
+            <dd class="rounded-all"><p>true if required, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="questions"><span class="">questions</span></dt>
+            <dd class="rounded-all"><p>List of profile questions organizer would like new members to answer prior to joining</p></dd>
+            
+            <dt class="align-right bold" title="questions_req"><span class="">questions_req</span></dt>
+            <dd class="rounded-all"><p>true if required, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo, returned when fields request parameter value includes 'group_key_photo'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate group latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate group longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Membership dues information associated with hosting group, returned when fields request parameter value includes 'group_membership_dues'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency in which the fee is declared</p></dd>
+            
+            <dt class="align-right bold" title="dues_links"><span class="">dues_links</span></dt>
+            <dd class="rounded-all"><p>Links to dues management and checkout pages.</p></dd>
+            
+            <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+            <dd class="rounded-all"><p>Numeric fee value</p></dd>
+            
+            <dt class="align-right bold" title="fee_desc"><span class="">fee_desc</span></dt>
+            <dd class="rounded-all"><p>The interval at which dues must be paid. Possible values may include: "month", "year", "day", or "every other day"</p></dd>
+            
+            <dt class="align-right bold" title="methods"><span class="">methods</span></dt>
+            <dd class="rounded-all"><p>Methods of payments</p></dd>
+            
+            <dt class="align-right bold" title="reasons"><span class="">reasons</span></dt>
+            <dd class="rounded-all"><p>Array of reasons containing one or more of the following values compensate_organizer, cover_costs, encourage_engagement, improve_meetups, other, provide_supplies, reserve_fund</p></dd>
+            
+            <dt class="align-right bold" title="reasons_other"><span class="">reasons_other</span></dt>
+            <dd class="rounded-all"><p>An additional reason if specified.</p></dd>
+            
+            <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+            <dd class="rounded-all"><p>Conditions for refunds</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>true if dues are required</p></dd>
+            
+            <dt class="align-right bold" title="required_to"><span class="">required_to</span></dt>
+            <dd class="rounded-all"><p>If the dues are required this indicates what they are required for. Currently may only be 'join'</p></dd>
+            
+            <dt class="align-right bold" title="self_payment_required"><span class="">self_payment_required</span></dt>
+            <dd class="rounded-all"><p>Returns true if the authorized user is prevented from participating in the group until a payment is made</p></dd>
+            
+            <dt class="align-right bold" title="trial_days"><span class="">trial_days</span></dt>
+            <dd class="rounded-all"><p>When present, returns the number of days the group is offering a free trial period for to new members. When not present, this indicates that the group does not offer a trial membership period</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="meta_category"><span class="">meta_category</span></dt>
+       <dd class="rounded-all">
+        <p>The meta category of the group, if the group has one, returned when fields request parameter value inclues 'meta_category'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="best_topics"><span class="">best_topics</span></dt>
+            <dd class="rounded-all"><p>Represents the best topic matches for this category, returned when the "fields"
+request parameter value includes "best_topics"</p></dd>
+            
+            <dt class="align-right bold" title="category_ids"><span class="">category_ids</span></dt>
+            <dd class="rounded-all"><p>List of numeric category ids associated with this topic category</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic-category id</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic-category</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Photo representing this category</p></dd>
+            
+            <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+            <dd class="rounded-all"><p>Unique string identifier for this category</p></dd>
+            
+            <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+            <dd class="rounded-all"><p>Name used for sorting</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count"><span class="">past_event_count</span></dt>
+       <dd class="rounded-all">
+        <p>The number of past events belonging to the group, returned when "fields" includes "group_past_event_count"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Photo associated with group, returned when fields request parameter value includes 'group_photo'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used to generate group duotone, returned when fields request parameter value includes 'group_photo_gradient'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="pro_network"><span class="">pro_network</span></dt>
+       <dd class="rounded-all">
+        <p>Information on group's Pro organization, returned when "fields" request parameter value includes "group_pro_network"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="region"><span class="">region</span></dt>
+       <dd class="rounded-all">
+        <p>Language and region of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self"><span class="">self</span></dt>
+       <dd class="rounded-all">
+        <p>Information pertaining to the authenticated member with respect to the group, returned when fields request parameter value includes 'group_self_profile', 'group_self_actions', 'group_self_membership_dues', or 'group_self_status'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+            <dd class="rounded-all"><p>list of actions the authenticated member may perform, potentially "event_create": the ability to create new events, "event_draft": the ability to save new events as drafts, "role_assign": the ability to assign member roles, "edit": the ability to edit group settings, "member_approval": the ability to approve or decline member requests to join, or "subscription_upgrade": the ability to upgrade this group's subscription plan</p></dd>
+            
+            <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+            <dd class="rounded-all"><p>Membership dues information associated with hosting group, returned when "fields" request parameter value includes "group_membership_dues" and group has dues</p></dd>
+            
+            <dt class="align-right bold" title="profile"><span class="">profile</span></dt>
+            <dd class="rounded-all"><p>Profile of the authenticated member</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Indicates the authorized user's membership with this group.</p>
+<p>Value may be one of "none", "pending", "pending_payment", "active", or "blocked"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+       <dd class="rounded-all">
+        <p>Timezone of group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>Topics related to the group, returned when fields request parameter value includes 'group_topics'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic id</p></dd>
+            
+            <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+            <dd class="rounded-all"><p>Language topic originates from</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic</p></dd>
+            
+            <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+            <dd class="rounded-all"><p>The unique keyword used to identify this topic</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric urlname identifier for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+       <dd class="rounded-all">
+        <p>Group visibility, returned when fields request parameter value includes 'group_visibility'. Value may be "public", "public_limited", or "members".</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="how_to_find_us"><span class="">how_to_find_us</span></dt>
+    <dd class="rounded-all">
+    <p>Additional information on how to find members at a venue when provided by an organizer, returned when fields request parameter value includes 'how_to_find_us'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>A unique alphanumeric identifier for event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+    <dd class="rounded-all">
+    <p>Is event happening online</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to event on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+    <dd class="rounded-all">
+    <p>The local date of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+    <dd class="rounded-all">
+    <p>The local time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="manual_attendance_count"><span class="">manual_attendance_count</span></dt>
+    <dd class="rounded-all">
+    <p>Manually entered total attendee headcount, if any exists</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of the event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+    <dd class="rounded-all">
+    <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+    <dd class="rounded-all">
+    <p>Information about photo uploads for this event, returned when fields request parameter value includes 'photo_album'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="event"><span class="">event</span></dt>
+       <dd class="rounded-all">
+        <p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric event ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of event</p></dd>
+            
+            <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of no RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="time"><span class="">time</span></dt>
+            <dd class="rounded-all"><p>UTC start time of the event, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+            <dd class="rounded-all"><p>The local offset from UTC time, in milliseconds</p></dd>
+            
+            <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+            <dd class="rounded-all"><p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of yes RSVPs</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for photo album</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of photos uploaded</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection of photos uploaded for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Album title</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_description"><span class="">plain_text_description</span></dt>
+    <dd class="rounded-all">
+    <p>Plain text version of the event description. Email addresses and photo numbers will be masked for non-members. Returned when "fields" request parameter value contains "plain_text_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_no_images_description"><span class="">plain_text_no_images_description</span></dt>
+    <dd class="rounded-all">
+    <p>Plain text version of the event description without images. Email addresses and photo numbers will be masked for non-members. Returned when "fields" request parameter value contains "plain_text_no_images_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+    <dd class="rounded-all">
+    <p>The number of "yes" RSVPS an event has capacity for</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_rules"><span class="">rsvp_rules</span></dt>
+    <dd class="rounded-all">
+    <p>Information about conditions that allow for member RSVPs, returned when fields request parameter value include 'rsvp_rules'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="close_time"><span class="">close_time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC time that RSVPs will no longer be accepted, though organizers may close RSVPs earlier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="closed"><span class="">closed</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean value indicating whether or not RSVPing was explicitly closed for the event.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="guest_limit"><span class="">guest_limit</span></dt>
+       <dd class="rounded-all">
+        <p>Number of guests members may include in their RSVP, 0 or more</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="open_time"><span class="">open_time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC time that members may begin to RSVP</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+       <dd class="rounded-all">
+        <p>The organizer-defined terms for refunds. If this is defined, you must provide the authenticated member a way to access this information before they can RSVP. They will need to agree to these terms before they RSVP</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="days"><span class="">days</span></dt>
+            <dd class="rounded-all"><p>if member_cancellation is present, it's relative to this many days before the event</p></dd>
+            
+            <dt class="align-right bold" title="notes"><span class="">notes</span></dt>
+            <dd class="rounded-all"><p>additional refund policy notes</p></dd>
+            
+            <dt class="align-right bold" title="policies"><span class="">policies</span></dt>
+            <dd class="rounded-all"><p>list of one or more of the following. 'no_refunds' if the organizer will not issue refunds', 'member_cancellation' if the organizer offers a refund for member cancellation, 'event_cancellation' if the organizer offers a refund if the event is canceled, 'event_rescheduled' if the organizer offers a refund when the event is rescheduled</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlisting"><span class="">waitlisting</span></dt>
+       <dd class="rounded-all">
+        <p>Wait list handling when RSVP limit is reached. Value may be one of 'auto', 'manual' or 'off'</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection RSVPs for members attending this event, returned when fields request parameter value includes 'rsvp_sample'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the RSVP, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="member"><span class="">member</span></dt>
+       <dd class="rounded-all">
+        <p>Member who RSVP'd</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+            <dd class="rounded-all"><p>Intro of member</p></dd>
+            
+            <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+            <dd class="rounded-all"><p>Member's context within the event. Only returned in the context of an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric member ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of member</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="self"><span class="">self</span></dt>
+            <dd class="rounded-all"><p>Represents the authenticated member's relation to member.
+Returned with the "fields" request parameter includes "self" and
+the target member is not the authenticated member</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time of the RSVP, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvpable"><span class="">rsvpable</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean value indicating whether or not the authenticated member can RSVP or join the waitlist when the event is full.
+Returned when the "fields" request parameter value
+includes "rsvpable"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvpable_after_join"><span class="">rsvpable_after_join</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean value indicating whether or not the authenticated member can RSVP
+after joining the hosting group.
+Returned when the "fields" request parameter
+includes "rsvpable_after_join"
+and the authenticated member is <em>not</em> a member of the
+group hosting this event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="saved"><span class="">saved</span></dt>
+    <dd class="rounded-all">
+    <p>Whether the authorized member has saved the event, returned when fields request parameter value includes 'saved'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>represents details particular to the authorized user, only present if requested and authenticated member is a member of the hosting group, returned when fields request parameter value includes 'self'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform, potentially one or more of the following</p>
+<p>"announce" to announce the event to the group's members</p>
+<p>"attendance" to view or take attendance for the event</p>
+<p>"copy" the ability to copy an event</p>
+<p>"comment" the ability to post a comment or reply</p>
+<p>"payments" the ability to mark members as paid if the event is ticketed</p>
+<p>"publish" to publish a draft event</p>
+<p>"edit" to edit the event information</p>
+<p>"edit_hosts" to edit the hosts for the event</p>
+<p>"email_attendees" the ability to email event attendees</p>
+<p>"delete" to delete the event</p>
+<p>"rsvp" to RSVP yes or no to the event</p>
+<p>"wait" to get on the waiting list (using the same RSVP methods).</p>
+<p>"dues" if an organizer requires membership dues to RSVP and the authorized
+ member has not paid theirs</p>
+<p>"upload_photo" the ability to upload a photo for the event</p>
+<p>"cancel" the ability to cancel the event</p>
+<p>"close" the ability to close the RSVPs for the event</p>
+<p>"open" the ability to open the RSVPs for the event</p>
+<p>"invite" the ability to invite someone for the event</p>
+<p>"download_attendees" the ability to download the attendees list for the event</p>
+<p>"take_attendance" the ability to take attendance for the event</p>
+<p>"delete_cancelled" the ability to delete the event if it is cancelled</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="pay_status"><span class="">pay_status</span></dt>
+       <dd class="rounded-all">
+        <p>The authenticated member's payment status. This may be one of 'none', 'paid', 'partially_paid', 'payment_pending', 'echeck_pending', 'refund_pending', 'partially_refunded', 'refunded'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The authenticated member's role in within the group, if any. This may be one of: Organizer, Assistant Organizer, Event Organizer, etc.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp"><span class="">rsvp</span></dt>
+       <dd class="rounded-all">
+        <p>Member's RSVP, if any</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+            <dd class="rounded-all"><p>List of answers to event survey questions asked when the member RSVP'd in the order asked, only available to organizers and assistant organizers</p></dd>
+            
+            <dt class="align-right bold" title="guests"><span class="">guests</span></dt>
+            <dd class="rounded-all"><p>Number of guests the RSVP'd member will be bringing</p></dd>
+            
+            <dt class="align-right bold" title="response"><span class="">response</span></dt>
+            <dd class="rounded-all"><p>May be "yes" or "no".</p>
+<p>In cases where an event is over capacity and the member has shown an intent to attend,
+response may be "waitlist" if the event has a waitlist.</p>
+<p>In cases of ticketed events, this may be "yes_pending_payment"
+for a "yes" response for a ticketed event with an unprocessed payment</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="series"><span class="">series</span></dt>
+    <dd class="rounded-all">
+    <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="description"><span class="">description</span></dt>
+       <dd class="rounded-all">
+        <p>Human displayable description of how often events in this series occur</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+       <dd class="rounded-all">
+        <p>Date when this series ends/ended, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the series</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+       <dd class="rounded-all">
+        <p>Returned for events that are part of a monthly recurring series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="day_of_week"><span class="">day_of_week</span></dt>
+            <dd class="rounded-all"><p>Integer value between 1-7 (Monday-Sunday) for the day of week the recurrence occurs upon</p></dd>
+            
+            <dt class="align-right bold" title="interval"><span class="">interval</span></dt>
+            <dd class="rounded-all"><p>Integer number of months between each recurrence</p></dd>
+            
+            <dt class="align-right bold" title="week_of_month"><span class="">week_of_month</span></dt>
+            <dd class="rounded-all"><p>Integer value between 1-5 representing the week number on which the event recurs. A value of 5 indicates the event recurs on the last week of every month</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+       <dd class="rounded-all">
+        <p>Date when this series begins/began, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the template event of the series</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+       <dd class="rounded-all">
+        <p>Returned for events that are part of a weekly recurring series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="days_of_week"><span class="">days_of_week</span></dt>
+            <dd class="rounded-all"><p>List of integers 1-7 (Monday-Sunday) of days of week recurrence occurs upon</p></dd>
+            
+            <dt class="align-right bold" title="interval"><span class="">interval</span></dt>
+            <dd class="rounded-all"><p>Integer number of weeks between each recurrence</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>A shortened link for the event on meetup.com, returned when fields request parameter value includes "short_link"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="simple_html_description"><span class="">simple_html_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the event, in simple HTML source format. If this event's description was saved in simple HTML format, the description field will be an HTML translation of this source. Returned when the "fields"' request parameter contains "simple_html_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>"cancelled", "upcoming", "past", "proposed", "suggested", or "draft"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+    <dd class="rounded-all">
+    <p>List of organizer-defined survey questions intended to be asked of RSVPing members. Returned when the "fields"' request parameter contains "answers"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric question identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="question"><span class="">question</span></dt>
+       <dd class="rounded-all">
+        <p>Question text</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="time"><span class="">time</span></dt>
+    <dd class="rounded-all">
+    <p>UTC start time of the event, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Last modified time for the event in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The local offset from UTC time, in milliseconds</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+    <dd class="rounded-all">
+    <p>The event venue, present only if selected and not hidden by an organizer</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+       <dd class="rounded-all">
+        <p>Line 1 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+       <dd class="rounded-all">
+        <p>Line 2 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+       <dd class="rounded-all">
+        <p>Line 3 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="city"><span class="">city</span></dt>
+       <dd class="rounded-all">
+        <p>City of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country code of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric venue id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+       <dd class="rounded-all">
+        <p>The localized name of the venue's country</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Venue name</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+       <dd class="rounded-all">
+        <p>Phone number of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+       <dd class="rounded-all">
+        <p>true if the editor of the event altered the original venues pin location, false otherwise</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State of venue where available</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+       <dd class="rounded-all">
+        <p>ZIP code if, venue is in US or Canada</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="venue_visibility"><span class="">venue_visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Represents who can see the venue with a potential value of "members" or "public", returned when fields request parameter value includes "venue_visibility" and the authenticated member is a member of the group hosting the event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Event visibility: "public", "public_limited", or "members". Events in private groups that do not expose limited information are visible only to that group's members and should not be made public.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of members on the waitlist, if one exists</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="web_actions"><span class="">web_actions</span></dt>
+    <dd class="rounded-all">
+    <p>Set of "Invite" and google/yahoo/ical/outlook "Add to calendar" web actions</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="why"><span class="">why</span></dt>
+    <dd class="rounded-all">
+    <p>We should do this because...</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of yes RSVPs including guests</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_events_:event_id_abuse_reports.html
+++ b/test/data/_:urlname_events_:event_id_abuse_reports.html
@@ -1,0 +1,71 @@
+
+        
+
+<div id="">
+  <h2>Report Event</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname/events/:event_id/abuse_reports
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">reporting</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Submits a new abuse report for a target event. Abuse reports will be followed up on by our Community Support team.</p>
+  </div>
+  
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>This method requires the oauth <code>reporting</code> scope for oauth-authenticated requests</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="comments"><span class="">comments</span></dt>
+    <dd class="rounded-all"><p>An optional string of text that describes why you are submitting this report</p></dd>
+  
+    <dt class="align-right bold" title="type"><span class="param_required">type</span></dt>
+    <dd class="rounded-all"><p>A required identifier for type of abuse you are reporting. Acceptable values include violent_or_hateful:violent, violent_or_hateful:hateful, violent_or_hateful:misinformation, violent_or_hateful:other, inappropriate:sexually_explicit, inappropriate:misinformation, inappropriate:sexual_exploitation, inappropriate:licensed_services, inappropriate:underage, inappropriate:illegal, inappropriate:intellectual_property, inappropriate:other, poor_quality_or_spam:spam, poor_quality_or_spam:misleading_title, poor_quality_or_spam:misinformation, poor_quality_or_spam:not_irl, poor_quality_or_spam:no_description, poor_quality_or_spam:other, irl:hateful, irl:violent, irl:misrepresentation, irl:no_host, irl:other</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>A successful abuse report request will result in a 202 Accepted response</p>
+  <dl>
+  
+  </dl>
+  
+  
+  <h3 id="examples" class="rounded-all">Examples</h3>
+  <p>Submit an abuse report for an event {event_id} belonging to group {urlname} that doesn't appear to be fostering a healthy community</p>
+<pre><code>curl -H "Authorization: Bearer {token}" \
+  "https://api.meetup.com/{urlname}/events/{event_id}/abuse_reports" \
+  -d "type=not_community"
+</code></pre>
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_events_:event_id_comments.html
+++ b/test/data/_:urlname_events_:event_id_comments.html
@@ -1,0 +1,466 @@
+
+        
+
+<div id="list">
+  <h2>Event Comments List</h2>
+  <div id="listuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/events/:event_id/comments
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Lists the comments and replies posted in a given Meetup Event.</p>
+<p>To view the list of likes for a comment or reply
+see the <a href="/meetup_api/docs/:urlname/events/:event_id/comments/:comment_id/likes/">likes</a>
+endpoint</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/events/:event_id/comments">Try it in the console</a></p>
+  <h3 id="listparams" class="rounded-all">Request Parameters</h3>
+  <div class="listparam-notes"><p>A valid path parameter for <strong>:urlname</strong> and <strong>:event_id</strong>
+is required.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional fields to append to the response.
+Currently only "self" is supported</p></dd>
+  
+  </dl>
+  
+  <h3 id="listresponse" class="rounded-all">Response</h3>
+  <p>Returns a list of comments and their replies.</p>
+<p>If the organizer
+of the Meetup group hosting the event these comments were posted in
+has chosen to restrict the visibility of their group to members,
+and the authenticated member is not a member of that group, a 403
+Forbidden response will be returned.</p>
+  <dl>
+   
+    <dt class="align-right bold" title="comment"><span class="">comment</span></dt>
+    <dd class="rounded-all">
+    <p>The comment the member left for the event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time the comment was posted in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Comment id</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="in_reply_to"><span class="">in_reply_to</span></dt>
+    <dd class="rounded-all">
+    <p>The id of the comment a reply was in relation to</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="like_count"><span class="">like_count</span></dt>
+    <dd class="rounded-all">
+    <p>The number of likes the comment has</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>The member that made the comment.</p>
+<p>In cases where member has since left the group,
+this member may have an id of 0</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Intro of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+       <dd class="rounded-all">
+        <p>Member's context within the event. Only returned in the context of an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host"><span class="">host</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator for whether this member is a host for the event</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="replies"><span class="">replies</span></dt>
+    <dd class="rounded-all">
+    <p>A list of replies, with the same structure as a comment.
+This field may be absent in cases where there are no replies</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Context for the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>A list of actions the authenticated member may perform on the comment.</p>
+<p>Value may be one or more of the following:</p>
+<p><strong>flag_spam</strong> mark this comment as spam</p>
+<p><strong>delete</strong> delete this comment</p>
+<p><strong>unlike</strong> unlike this comment</p>
+<p><strong>like</strong> like this comment</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="liked"><span class="">liked</span></dt>
+       <dd class="rounded-all">
+        <p>A boolean indicator of whether or not the authenticated member has liked the comment</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="notifications"><span class="">notifications</span></dt>
+       <dd class="rounded-all">
+        <p>Indicator of whether or not the authenticated member may
+              receive notifications about related comments. May be one of 'on' or 'off'</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="create">
+  <h2>Event comment and reply</h2>
+  <div id="createuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname/events/:event_id/comments
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">group_content_edit</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Creates new comments and replies to existing comments within an Meetup event</p>
+  </div>
+  
+  <h3 id="createparams" class="rounded-all">Request Parameters</h3>
+  <div class="createparam-notes"><p>A path parameter for <strong>:urlname</strong>, <strong>:event_id</strong>,
+and <strong>:comment_id</strong> is required.</p>
+<p>In addition,
+authorized oauth applications should request the
+<a href="/meetup_api/auth/#group_content_edit_scope">group_content_edit</a> permission scope.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="comment"><span class="param_required">comment</span></dt>
+    <dd class="rounded-all"><p>The text of the comment in at most 1024 characters</p></dd>
+  
+    <dt class="align-right bold" title="in_reply_to"><span class="">in_reply_to</span></dt>
+    <dd class="rounded-all"><p>If posting a reply, set this to the numeric identifier of the associated top level comment</p></dd>
+  
+    <dt class="align-right bold" title="notifications"><span class="">notifications</span></dt>
+    <dd class="rounded-all"><p>A boolean value indicating whether or not you wish to recieve future notifications about updates to this comment thread</p></dd>
+  
+  </dl>
+  
+  <h3 id="createresponse" class="rounded-all">Response</h3>
+  <p>A successful request will yield a new comment or reply encoded in JSON</p>
+  <dl>
+   
+    <dt class="align-right bold" title="comment"><span class="">comment</span></dt>
+    <dd class="rounded-all">
+    <p>The comment the member left for the event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time the comment was posted in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Comment id</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="in_reply_to"><span class="">in_reply_to</span></dt>
+    <dd class="rounded-all">
+    <p>The id of the comment a reply was in relation to</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="like_count"><span class="">like_count</span></dt>
+    <dd class="rounded-all">
+    <p>The number of likes the comment has</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>The member that made the comment.</p>
+<p>In cases where member has since left the group,
+this member may have an id of 0</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Intro of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+       <dd class="rounded-all">
+        <p>Member's context within the event. Only returned in the context of an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host"><span class="">host</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator for whether this member is a host for the event</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="replies"><span class="">replies</span></dt>
+    <dd class="rounded-all">
+    <p>A list of replies, with the same structure as a comment.
+This field may be absent in cases where there are no replies</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Context for the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>A list of actions the authenticated member may perform on the comment.</p>
+<p>Value may be one or more of the following:</p>
+<p><strong>flag_spam</strong> mark this comment as spam</p>
+<p><strong>delete</strong> delete this comment</p>
+<p><strong>unlike</strong> unlike this comment</p>
+<p><strong>like</strong> like this comment</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="liked"><span class="">liked</span></dt>
+       <dd class="rounded-all">
+        <p>A boolean indicator of whether or not the authenticated member has liked the comment</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="notifications"><span class="">notifications</span></dt>
+       <dd class="rounded-all">
+        <p>Indicator of whether or not the authenticated member may
+              receive notifications about related comments. May be one of 'on' or 'off'</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+  
+  </dl>
+  
+  <h4 id="createerrors" class="rounded-all">Errors</h4>
+  <dl>
+  
+    <dt class="align-right bold"><span class="">comment_error</span></dt>
+    <dd><p>Comment appeared to contain spam</p></dd>
+  
+    <dt class="align-right bold"><span class="">event_error</span></dt>
+    <dd><p>Invalid event</p></dd>
+  
+    <dt class="align-right bold"><span class="">in_reply_to_error</span></dt>
+    <dd><p>in_reply_to not a valid comment</p></dd>
+  
+    <dt class="align-right bold"><span class="">post_error</span></dt>
+    <dd><p>Over daily limit of 20</p></dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_events_:event_id_comments_:comment_id.html
+++ b/test/data/_:urlname_events_:event_id_comments_:comment_id.html
@@ -1,0 +1,67 @@
+
+        
+
+<div id="delete">
+  <h2>Event comment delete</h2>
+  <div id="deleteuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">DELETE</strong> /:urlname/events/:event_id/comments/:comment_id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">group_content_edit</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Deletes comments posted in events</p>
+  </div>
+  
+  <h3 id="deleteparams" class="rounded-all">Request Parameters</h3>
+  <div class="deleteparam-notes"><p>A path parameter for <strong>:urlname</strong>, <strong>:event_id</strong>,
+and <strong>:comment_id</strong> is required.</p>
+<p>The <strong>:comment_id</strong> path parameter should be formatted as <code>comment:{comment_id}</code>
+for top level comments or <code>reply:{reply_id}</code> for comment replies</p>
+<p>To obtain a list of comments and their replies for an event, see the
+<a href="/meetup_api/docs/:urlname/events/:event_id/comments/">event comments</a> endpoint</p>
+<p>Only organizers or the member that posted the comment may delete the comment</p>
+<p>In addition,
+authorized oauth applications should request the
+<a href="/meetup_api/auth/#group_content_edit_scope">group_content_edit</a> permission scope.</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="deleteresponse" class="rounded-all">Response</h3>
+  <p>A successful request will result in an HTTP 204 NoContent response</p>
+  <dl>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_events_:event_id_comments_:comment_id_likes.html
+++ b/test/data/_:urlname_events_:event_id_comments_:comment_id_likes.html
@@ -1,0 +1,274 @@
+
+        
+
+<div id="list">
+  <h2>Event Comment and Reply Likes</h2>
+  <div id="listuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/events/:event_id/comments/:comment_id/likes
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Returns lists of likes for an event comment or reply</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/events/:event_id/comments/:comment_id/likes">Try it in the console</a></p>
+  <h3 id="listparams" class="rounded-all">Request Parameters</h3>
+  <div class="listparam-notes"><p>A path parameter for <strong>:urlname</strong>,  <strong>:event_id</strong>,
+and <strong>:comment_id</strong> is required</p>
+<p>The <strong>:comment_id</strong> should be formatted as <code>comment:{comment_id}</code> for top level comments
+or <code>reply:{reply_id}</code> for comment replies.</p>
+<p>To obtain a list of comments and their replies for an event, see the
+<a href="/meetup_api/docs/:urlname/events/:event_id/comments/">event comments</a> endpoint</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="listresponse" class="rounded-all">Response</h3>
+  <p>Returns a list of likes</p>
+  <dl>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time of like, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>Member associated with the like</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Intro of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+       <dd class="rounded-all">
+        <p>Member's context within the event. Only returned in the context of an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host"><span class="">host</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator for whether this member is a host for the event</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Time like was updated, in milliseconds since the epoch</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="create">
+  <h2>Event Comment Like</h2>
+  <div id="createuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname/events/:event_id/comments/:comment_id/likes
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Like a given event comment</p>
+  </div>
+  
+  <h3 id="createparams" class="rounded-all">Request Parameters</h3>
+  <div class="createparam-notes"><p>A path parameter for <strong>:urlname</strong>,  <strong>:event_id</strong>,
+and <strong>:comment_id</strong> is required</p>
+<p>The <strong>:comment_id</strong> should be formatted as <code>comment:{comment_id}</code> for top level comments
+or <code>reply:{reply_id}</code> for comment replies.</p>
+<p>To obtain a list of comments and their replies for an event, see the
+<a href="/meetup_api/docs/:urlname/events/:event_id/comments/">event comments</a> endpoint</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="createresponse" class="rounded-all">Response</h3>
+  <p>Returns an HTTP 204 response if like was successful, 401 if unauthorized.</p>
+  <dl>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="delete">
+  <h2>Event Comment Unlike</h2>
+  <div id="deleteuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">DELETE</strong> /:urlname/events/:event_id/comments/:comment_id/likes
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Unlike a given event comment</p>
+  </div>
+  
+  <h3 id="deleteparams" class="rounded-all">Request Parameters</h3>
+  <div class="deleteparam-notes"><p>A path parameter for <strong>:urlname</strong>,  <strong>:event_id</strong>,
+and <strong>:comment_id</strong> is required</p>
+<p>The <strong>:comment_id</strong> should be formatted as <code>comment:{comment_id}</code> for top level comments
+or <code>reply:{reply_id}</code> for comment replies.</p>
+<p>To obtain a list of comments and their replies for an event, see the
+<a href="/meetup_api/docs/:urlname/events/:event_id/comments/">event comments</a> endpoint</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="deleteresponse" class="rounded-all">Response</h3>
+  <p>Returns an HTTP 204 response if unlike was successful, 401 if unauthorized.</p>
+  <dl>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_events_:event_id_hosts.html
+++ b/test/data/_:urlname_events_:event_id_hosts.html
@@ -1,0 +1,459 @@
+
+        
+
+<div id="">
+  <h2>Event Hosts</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/events/:event_id/hosts
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Returns the list of hosts for a given event</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/events/:event_id/hosts">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>A valid <strong>:urlname</strong> and <strong>:event_id</strong> is required.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional fields to append to the response</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>Response a list of group member profile objects encoded as JSON. This list is not paginated</p>
+  <dl>
+   
+    <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+    <dd class="rounded-all">
+    <p>Member bio. When profile does not belong to the authenticated member, this may be omitted if member opted to hide their bio from others</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="birthday"><span class="">birthday</span></dt>
+    <dd class="rounded-all">
+    <p>Returned only when the fields request parameter value includes 'birthday'
+and only for the authenticated member when defined</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="day"><span class="">day</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric day member was born. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="month"><span class="">month</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric month member was born. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="year"><span class="">year</span></dt>
+       <dd class="rounded-all">
+        <p>Year member was born</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country code associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="email"><span class="">email</span></dt>
+    <dd class="rounded-all">
+    <p>Member email address. Provided only if a profile belongs to the authenticated member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="gender"><span class="">gender</span></dt>
+    <dd class="rounded-all">
+    <p>Returned only when the fields request parameter value includes "gender"
+and only for the authenticated member.
+Value may be one of "female", "male", "none", or "other".
+This field may be absent where gender is not defined</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_profile"><span class="">group_profile</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup Group profile information.
+This field is only returned when profile is requested in group contexts</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+       <dd class="rounded-all">
+        <p>Array of answers to Group Profile questions</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="answer"><span class="">answer</span></dt>
+            <dd class="rounded-all"><p>Answer text</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+            <dt class="align-right bold" title="question_id"><span class="">question_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric question identifier</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>The time this member joined the Group, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>The group associated with this membership</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+            <dd class="rounded-all"><p>Group photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric group ID</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Who can join this group and how. One of "approval", "closed", or "open"</p></dd>
+            
+            <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+            <dd class="rounded-all"><p>Group primary photo</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+            <dd class="rounded-all"><p>Color combination used generate group duotone</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Status of the group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Urlname used to identify the group on meetup.com</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="intro"><span class="">intro</span></dt>
+       <dd class="rounded-all">
+        <p>Member intro, may be omitted if member opted to hide their intro from other members</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="link"><span class="">link</span></dt>
+       <dd class="rounded-all">
+        <p>Member profile link, provides a link to the members chapter profile</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the Group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Membership status in this Group.
+Value may be one of
+active, blocked, pending, pending_payment or none</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>The last time this member edited their Group profile, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+       <dd class="rounded-all">
+        <p>The last time this member visited the Group, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Unique numeric identifier for the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_pro_admin"><span class="">is_pro_admin</span></dt>
+    <dd class="rounded-all">
+    <p>Returns true if the member is an active admin of an active meetup pro network</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="joined"><span class="">joined</span></dt>
+    <dd class="rounded-all">
+    <p>Time member joined, represented as milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Geographic latitude associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of country associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Geographic longitude associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="messaging_pref"><span class="">messaging_pref</span></dt>
+    <dd class="rounded-all">
+    <p>The member's preference for being contacted from other members on the platform.
+Returned only when the fields request parameter value includes "messaging_pref".
+May be one of the following: "all_members", "groups_only", or "orgs_only"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Display name for the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="other_services"><span class="">other_services</span></dt>
+    <dd class="rounded-all">
+    <p>An object whose key's are the names of associated external
+networks and values are identities within those networks.
+The keys may be one of facebook, flickr, linkedin, tumblr or twitter.
+Returned only when "fields" request parameter value
+includes "other_services"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="identifier"><span class="">identifier</span></dt>
+       <dd class="rounded-all">
+        <p>A unique string identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="url"><span class="">url</span></dt>
+       <dd class="rounded-all">
+        <p>A url for this identity. May be the same as identifier in some cases</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+    <dd class="rounded-all">
+    <p>Member photo. May be absent if member has not chosen one.
+In group contexts, the Member's Group profile photo will be returned.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="privacy"><span class="">privacy</span></dt>
+    <dd class="rounded-all">
+    <p>Member's privacy preferences
+Returned only when the "fields" request parameter value includes "privacy"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="facebook"><span class="">facebook</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' of 'visible'.
+If absent, the member has not connected their Facebook account to Meetup</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible'</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Represents the authenticated member's relation to member.
+Returned when "fields" request parameter value includes "self" and
+the target member is not the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions available for the authenticated member to perform.
+Currently only "message" is supported</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="blocks"><span class="">blocks</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indication of whether or not the authenticated member blocks this member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="common"><span class="">common</span></dt>
+       <dd class="rounded-all">
+        <p>Information the authenticated member has in common with this member</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+            <dd class="rounded-all"><p>List of common groups</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="friends"><span class="">friends</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indication of whether or not the authenticated member is a friend of the member</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State associated with Member's location, where available</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>a string with one of the following values: {'active', 'prereg', 'unknown'}</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_events_:event_id_photos.html
+++ b/test/data/_:urlname_events_:event_id_photos.html
@@ -1,0 +1,931 @@
+
+        
+
+<div id="list">
+  <h2>Event Photos</h2>
+  <div id="listuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/events/:event_id/photos
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Lists photos for a given event</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/events/:event_id/photos">Try it in the console</a></p>
+  <h3 id="listparams" class="rounded-all">Request Parameters</h3>
+  <div class="listparam-notes"><p>A valid path parameter for
+<strong>:urlname</strong> and <strong>:event_id</strong> is required</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="desc"><span class="">desc</span></dt>
+    <dd class="rounded-all"><p>Controls directional order or listing. Default false</p></dd>
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional response fields.
+Currently supported values are
+"comment_count", "self" and "short_link"</p></dd>
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>Number of items to return per-page of results. Defaults to 200</p></dd>
+  
+  </dl>
+  
+  <h3 id="listresponse" class="rounded-all">Response</h3>
+  <p>Returns a list of event photo objects</p>
+  <dl>
+   
+    <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+    <dd class="rounded-all">
+    <p>A base url that can be use to construct a photo url from its components</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="caption"><span class="">caption</span></dt>
+    <dd class="rounded-all">
+    <p>Photo caption, if defined</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="comment_count"><span class="">comment_count</span></dt>
+    <dd class="rounded-all">
+    <p>The number of comments posted about this photo.
+Returned when 'comment_count' is present
+in the 'fields' request parameter.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo was uploaded, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>Group the photo is associated with." +
+          "|Returned when 'group' is present " +
+          "|in the 'fields' request parameter.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric group ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used generate group duotone</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Status of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for full sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric photo ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to photo on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>Member who uploaded the photo. If member has since left the group,
+this will return a member with an id of 0</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Intro of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+       <dd class="rounded-all">
+        <p>Member's context within the event. Only returned in the context of an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host"><span class="">host</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator for whether this member is a host for the event</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+    <dd class="rounded-all">
+    <p>Photo album the photo is associated with</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="event"><span class="">event</span></dt>
+       <dd class="rounded-all">
+        <p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric event ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of event</p></dd>
+            
+            <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of no RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="time"><span class="">time</span></dt>
+            <dd class="rounded-all"><p>UTC start time of the event, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+            <dd class="rounded-all"><p>The local offset from UTC time, in milliseconds</p></dd>
+            
+            <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+            <dd class="rounded-all"><p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of yes RSVPs</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for photo album</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of photos uploaded</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Album title</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for standard sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Context for the authenticated member.
+Returned when 'self' is present
+in the 'fields' request parameter and the authenticated
+is a member of the group the photo is associated with.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform on this photo
+or its containing album, potentially one or more of the following</p>
+<p>"comment" if member can comment on this photo</p>
+<p>"delete" if the member can delete the photo</p>
+<p>"edit" if the member can edit the photo details</p>
+<p>"upload_photo" if the member can upload new photos</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Shortened link to photo on meetup.com. Returned when 'short_link'
+is present in the 'fields' request parameter</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for thumbnail sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="type"><span class="">type</span></dt>
+    <dd class="rounded-all">
+    <p>Type of photo. One of "event" or "member"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo was last updated, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric utc offset based on the timezone of the group
+hosting the event this photo was posted in</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="upload">
+  <h2>Event Photo Upload</h2>
+  <div id="uploaduri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname/events/:event_id/photos
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Support for uploading new Event photos</p>
+  </div>
+  
+  <h3 id="uploadparams" class="rounded-all">Request Parameters</h3>
+  <div class="uploadparam-notes"><p>A valid path parameter value for
+<strong>:urlname</strong> and <strong>:event_id</strong>
+is required</p>
+<p>This method expects an HTTP POST containing a Content-Type of <code>multipart/form-data</code>.
+Only the <code>photo</code> parameter, which represents the photo being uploaded, is required.</p>
+<p>Uploaded photos are fed into a separate photo staging process and may not be
+immediately available for display. To receive responses for photos that are immediately
+displayable, send the <code>await</code> request parameter with a value of <code>true</code>.</p>
+<p>A maximum of 500 photos are allowed for a given event.</p>
+<p>Authentication credentials should be omitted from the request body and be sent via
+HTTP Authorization header or as query string parameters</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="await"><span class="">await</span></dt>
+    <dd class="rounded-all"><p>Optional boolean parameter that will defer a request's a response until confirmation that photo is immediately displayable is received.</p></dd>
+  
+    <dt class="align-right bold" title="caption"><span class="">caption</span></dt>
+    <dd class="rounded-all"><p>Caption for display. Max length 255</p></dd>
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional response fields.
+Currently supported values are "self" and "comment_count"</p></dd>
+  
+    <dt class="align-right bold" title="photo"><span class="param_required">photo</span></dt>
+    <dd class="rounded-all"><p>Photo upload data, encoded as multipart/form-data. The maximum file size allowed is 10MB</p></dd>
+  
+  </dl>
+  
+  <h3 id="uploadresponse" class="rounded-all">Response</h3>
+  <p>A successful request will respond with an Event Photo object
+If a successful photo upload is immediately accessible, a 201 Created status is returned, otherwise a 202 Accepted status is returned</p>
+  <dl>
+   
+    <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+    <dd class="rounded-all">
+    <p>A base url that can be use to construct a photo url from its components</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="caption"><span class="">caption</span></dt>
+    <dd class="rounded-all">
+    <p>Photo caption, if defined</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="comment_count"><span class="">comment_count</span></dt>
+    <dd class="rounded-all">
+    <p>The number of comments posted about this photo.
+Returned when 'comment_count' is present
+in the 'fields' request parameter.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo was uploaded, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>Group the photo is associated with." +
+          "|Returned when 'group' is present " +
+          "|in the 'fields' request parameter.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric group ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used generate group duotone</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Status of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for full sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric photo ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to photo on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>Member who uploaded the photo. If member has since left the group,
+this will return a member with an id of 0</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Intro of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+       <dd class="rounded-all">
+        <p>Member's context within the event. Only returned in the context of an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host"><span class="">host</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator for whether this member is a host for the event</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+    <dd class="rounded-all">
+    <p>Photo album the photo is associated with</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="event"><span class="">event</span></dt>
+       <dd class="rounded-all">
+        <p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric event ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of event</p></dd>
+            
+            <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of no RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="time"><span class="">time</span></dt>
+            <dd class="rounded-all"><p>UTC start time of the event, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+            <dd class="rounded-all"><p>The local offset from UTC time, in milliseconds</p></dd>
+            
+            <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+            <dd class="rounded-all"><p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of yes RSVPs</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for photo album</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of photos uploaded</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Album title</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for standard sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Context for the authenticated member.
+Returned when 'self' is present
+in the 'fields' request parameter and the authenticated
+is a member of the group the photo is associated with.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform on this photo
+or its containing album, potentially one or more of the following</p>
+<p>"comment" if member can comment on this photo</p>
+<p>"delete" if the member can delete the photo</p>
+<p>"edit" if the member can edit the photo details</p>
+<p>"upload_photo" if the member can upload new photos</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Shortened link to photo on meetup.com. Returned when 'short_link'
+is present in the 'fields' request parameter</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for thumbnail sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="type"><span class="">type</span></dt>
+    <dd class="rounded-all">
+    <p>Type of photo. One of "event" or "member"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo was last updated, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric utc offset based on the timezone of the group
+hosting the event this photo was posted in</p>
+    
+    </dd>
+  
+  </dl>
+  
+  <h4 id="uploaderrors" class="rounded-all">Errors</h4>
+  <dl>
+  
+    <dt class="align-right bold"><span class="">caption_error</span></dt>
+    <dd><p>The provided caption was longer than 255 characters</p></dd>
+  
+    <dt class="align-right bold"><span class="">photo_error</span></dt>
+    <dd><p>Returned photo was either omitted from the request or was invalid</p></dd>
+  
+    <dt class="align-right bold"><span class="">upload_error</span></dt>
+    <dd><p>The process of uploading the photo failed</p></dd>
+  
+    <dt class="align-right bold"><span class="">upload_limit_error</span></dt>
+    <dd><p>A member uploaded more photos than allowed for this event</p></dd>
+  
+    <dt class="align-right bold"><span class="">upload_timeout_error</span></dt>
+    <dd><p>A awaited response timed out</p></dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_events_:event_id_photos_:photo_id.html
+++ b/test/data/_:urlname_events_:event_id_photos_:photo_id.html
@@ -1,0 +1,955 @@
+
+        
+
+<div id="get">
+  <h2>Event Photo</h2>
+  <div id="geturi" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/events/:event_id/photos/:photo_id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Gets information about a specific photo</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/events/:event_id/photos/:photo_id">Try it in the console</a></p>
+  <h3 id="getparams" class="rounded-all">Request Parameters</h3>
+  <div class="getparam-notes"><p>A valid path parameter value for
+<strong>:urlname</strong> and <strong>:event_id</strong>, and <strong>:photo_id</strong>
+is required</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional response fields.
+Currently supported values are
+"comment_count", "self" and "short_link"</p></dd>
+  
+  </dl>
+  
+  <h3 id="getresponse" class="rounded-all">Response</h3>
+  <p>Returns a list of Event Photo objects</p>
+  <dl>
+   
+    <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+    <dd class="rounded-all">
+    <p>A base url that can be use to construct a photo url from its components</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="caption"><span class="">caption</span></dt>
+    <dd class="rounded-all">
+    <p>Photo caption, if defined</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="comment_count"><span class="">comment_count</span></dt>
+    <dd class="rounded-all">
+    <p>The number of comments posted about this photo.
+Returned when 'comment_count' is present
+in the 'fields' request parameter.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo was uploaded, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>Group the photo is associated with." +
+          "|Returned when 'group' is present " +
+          "|in the 'fields' request parameter.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric group ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used generate group duotone</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Status of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for full sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric photo ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to photo on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>Member who uploaded the photo. If member has since left the group,
+this will return a member with an id of 0</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Intro of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+       <dd class="rounded-all">
+        <p>Member's context within the event. Only returned in the context of an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host"><span class="">host</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator for whether this member is a host for the event</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+    <dd class="rounded-all">
+    <p>Photo album the photo is associated with</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="event"><span class="">event</span></dt>
+       <dd class="rounded-all">
+        <p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric event ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of event</p></dd>
+            
+            <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of no RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="time"><span class="">time</span></dt>
+            <dd class="rounded-all"><p>UTC start time of the event, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+            <dd class="rounded-all"><p>The local offset from UTC time, in milliseconds</p></dd>
+            
+            <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+            <dd class="rounded-all"><p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of yes RSVPs</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for photo album</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of photos uploaded</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Album title</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for standard sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Context for the authenticated member.
+Returned when 'self' is present
+in the 'fields' request parameter and the authenticated
+is a member of the group the photo is associated with.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform on this photo
+or its containing album, potentially one or more of the following</p>
+<p>"comment" if member can comment on this photo</p>
+<p>"delete" if the member can delete the photo</p>
+<p>"edit" if the member can edit the photo details</p>
+<p>"upload_photo" if the member can upload new photos</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Shortened link to photo on meetup.com. Returned when 'short_link'
+is present in the 'fields' request parameter</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for thumbnail sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="type"><span class="">type</span></dt>
+    <dd class="rounded-all">
+    <p>Type of photo. One of "event" or "member"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo was last updated, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric utc offset based on the timezone of the group
+hosting the event this photo was posted in</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="edit">
+  <h2>Event Photo Edit</h2>
+  <div id="edituri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">PATCH</strong> /:urlname/events/:event_id/photos/:photo_id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">group_content_edit</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Edits photo details</p>
+  </div>
+  
+  <h3 id="editparams" class="rounded-all">Request Parameters</h3>
+  <div class="editparam-notes"><p>A valid path parameter value for
+<strong>:urlname</strong> and <strong>:event_id</strong>, and <strong>:photo_id</strong>
+is required</p>
+<p>OAuth authenticated applications should
+request the <a href="/meetup_api/auth/#group_content_edit_scope">group_content_edit</a>
+permission scope</p>
+<p>Only the member that uploaded the photo, the organizer, or the co-organizers may edit the photo details</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="caption"><span class="">caption</span></dt>
+    <dd class="rounded-all"><p>The photo caption. May be up to 255 characters. To remove a caption, just send an empty value</p></dd>
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional response fields.
+Currently supported values are
+"comment_count", "self" and "short_link"</p></dd>
+  
+  </dl>
+  
+  <h3 id="editresponse" class="rounded-all">Response</h3>
+  <p>Returns updated Event Photo object</p>
+  <dl>
+   
+    <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+    <dd class="rounded-all">
+    <p>A base url that can be use to construct a photo url from its components</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="caption"><span class="">caption</span></dt>
+    <dd class="rounded-all">
+    <p>Photo caption, if defined</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="comment_count"><span class="">comment_count</span></dt>
+    <dd class="rounded-all">
+    <p>The number of comments posted about this photo.
+Returned when 'comment_count' is present
+in the 'fields' request parameter.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo was uploaded, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>Group the photo is associated with." +
+          "|Returned when 'group' is present " +
+          "|in the 'fields' request parameter.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric group ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used generate group duotone</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Status of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for full sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric photo ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to photo on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>Member who uploaded the photo. If member has since left the group,
+this will return a member with an id of 0</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Intro of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+       <dd class="rounded-all">
+        <p>Member's context within the event. Only returned in the context of an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host"><span class="">host</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator for whether this member is a host for the event</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+    <dd class="rounded-all">
+    <p>Photo album the photo is associated with</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="event"><span class="">event</span></dt>
+       <dd class="rounded-all">
+        <p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric event ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of event</p></dd>
+            
+            <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of no RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="time"><span class="">time</span></dt>
+            <dd class="rounded-all"><p>UTC start time of the event, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+            <dd class="rounded-all"><p>The local offset from UTC time, in milliseconds</p></dd>
+            
+            <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+            <dd class="rounded-all"><p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of yes RSVPs</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for photo album</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of photos uploaded</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Album title</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for standard sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Context for the authenticated member.
+Returned when 'self' is present
+in the 'fields' request parameter and the authenticated
+is a member of the group the photo is associated with.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform on this photo
+or its containing album, potentially one or more of the following</p>
+<p>"comment" if member can comment on this photo</p>
+<p>"delete" if the member can delete the photo</p>
+<p>"edit" if the member can edit the photo details</p>
+<p>"upload_photo" if the member can upload new photos</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Shortened link to photo on meetup.com. Returned when 'short_link'
+is present in the 'fields' request parameter</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for thumbnail sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="type"><span class="">type</span></dt>
+    <dd class="rounded-all">
+    <p>Type of photo. One of "event" or "member"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo was last updated, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric utc offset based on the timezone of the group
+hosting the event this photo was posted in</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="delete">
+  <h2>Event Photo Delete</h2>
+  <div id="deleteuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">DELETE</strong> /:urlname/events/:event_id/photos/:photo_id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">group_content_edit</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Deletes a specified event photo</p>
+  </div>
+  
+  <h3 id="deleteparams" class="rounded-all">Request Parameters</h3>
+  <div class="deleteparam-notes"><p>A valid path parameter value for
+<strong>:urlname</strong> and <strong>:event_id</strong>, and <strong>:photo_id</strong>
+is required</p>
+<p>OAuth authenticated applications should
+request the <a href="/meetup_api/auth/#group_content_edit_scope">group_content_edit</a>
+permission scope</p>
+<p>Only the member that uploaded the photo, the organizer may delete the photo</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="deleteresponse" class="rounded-all">Response</h3>
+  <p>Returns a HTTP 200 response if the delete was successful, 401 if unauthorized</p>
+  <dl>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_events_:event_id_photos_:photo_id_comments.html
+++ b/test/data/_:urlname_events_:event_id_photos_:photo_id_comments.html
@@ -1,0 +1,361 @@
+
+        
+
+<div id="post">
+  <h2>Photo Comment</h2>
+  <div id="posturi" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname/events/:event_id/photos/:photo_id/comments
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">group_content_edit</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Creates a new photo comment</p>
+  </div>
+  
+  <h3 id="postparams" class="rounded-all">Request Parameters</h3>
+  <div class="postparam-notes"><p>Valid path parameters for <strong>:urlname</strong>, <strong>:event_id</strong>, and <strong>:photo_id</strong> are required.</p>
+<p>You must be a member of the group to post comments on the photo.</p>
+<p>In addition,
+authorized oauth applications must request the
+<a href="/meetup_api/auth/#group_content_edit_scope">group_content_edit</a> permission scope.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="comment"><span class="param_required">comment</span></dt>
+    <dd class="rounded-all"><p>The text of the comment</p></dd>
+  
+  </dl>
+  
+  <h3 id="postresponse" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="comment"><span class="">comment</span></dt>
+    <dd class="rounded-all">
+    <p>The comment the member left for the photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time the comment was posted in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Comment id</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>The member that made the comment.</p>
+<p>In cases where member has since left the group,
+this member may have an id of 0</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Intro of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+       <dd class="rounded-all">
+        <p>Member's context within the event. Only returned in the context of an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host"><span class="">host</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator for whether this member is a host for the event</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Context for the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>A list of actions the authenticated member may perform on the comment.</p>
+<p>Value may be one or more of the following:</p>
+<p><strong>delete</strong> delete this comment</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="get">
+  <h2>Photo Comments</h2>
+  <div id="geturi" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/events/:event_id/photos/:photo_id/comments
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Lists photo comments associated with a photo</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/events/:event_id/photos/:photo_id/comments">Try it in the console</a></p>
+  <h3 id="getparams" class="rounded-all">Request Parameters</h3>
+  <div class="getparam-notes"><p>Valid path parameters for <strong>:urlname</strong>, <strong>:event_id</strong>, and <strong>:photo_id</strong> are required</p>
+<p>For groups that have limited public visibilty on their content, you must be a member of the group to see these</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="getresponse" class="rounded-all">Response</h3>
+  <p>Returns list of comments posted for a photo. This listing does not support pagination.</p>
+  <dl>
+   
+    <dt class="align-right bold" title="comment"><span class="">comment</span></dt>
+    <dd class="rounded-all">
+    <p>The comment the member left for the photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time the comment was posted in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Comment id</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>The member that made the comment.</p>
+<p>In cases where member has since left the group,
+this member may have an id of 0</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Intro of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+       <dd class="rounded-all">
+        <p>Member's context within the event. Only returned in the context of an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host"><span class="">host</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator for whether this member is a host for the event</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Context for the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>A list of actions the authenticated member may perform on the comment.</p>
+<p>Value may be one or more of the following:</p>
+<p><strong>delete</strong> delete this comment</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_events_:event_id_photos_:photo_id_comments_:comment_id.html
+++ b/test/data/_:urlname_events_:event_id_photos_:photo_id_comments_:comment_id.html
@@ -1,0 +1,66 @@
+
+        
+
+<div id="delete">
+  <h2>Photo Comment Delete</h2>
+  <div id="deleteuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">DELETE</strong> /:urlname/events/:event_id/photos/:photo_id/comments/:comment_id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">group_content_edit</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Deletes photo comments</p>
+  </div>
+  
+  <h3 id="deleteparams" class="rounded-all">Request Parameters</h3>
+  <div class="deleteparam-notes"><p>A URI containing a valid group <strong>urlname</strong>,
+<strong>event_id</strong>, <strong>photo_id</strong>, and <strong>comment_id</strong>
+is required.</p>
+<p>The authenticated member must
+be the original poster of the comment or an admin of the group</p>
+<p>In addition,
+authorized oauth applications must request the
+<a href="/meetup_api/auth/#group_content_edit_scope">group_content_edit</a> permission scope.</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="deleteresponse" class="rounded-all">Response</h3>
+  <p>A successful HTTP DELETE request will yield a 204 No Content response.
+Otherwise a 400 Bad Request response can be expected</p>
+  <dl>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_events_:event_id_rsvps.html
+++ b/test/data/_:urlname_events_:event_id_rsvps.html
@@ -1,0 +1,1143 @@
+
+        
+
+<div id="">
+  <h2>RSVP Create and Update</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname/events/:event_id/rsvps
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">rsvp</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Creates or updates an existing RSVP</p>
+  </div>
+  
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>The RSVP with be attributed to the currently authenticated member.</p>
+<p>Organizers may define a set of survey questions they intend members to answer when
+RSVPing. Members RSVPing may provide answers to those questions
+by supplying parameter names that correspond with question identifiers.
+To resolve any defined survey questions, you can inspect the
+<a href="/meetup_api/docs/:urlname/events/:id/#get">Event Get</a>'s
+response body for the 'survey_questions' field</p>
+<p>If the Event requires payment, you are required to send an
+'agree_to_refund' parameter set to true. This represents
+the authenticated Member's agreement to understanding the
+Event's refund policy.</p>
+<p>Note: When space is not available, "yes" responses may be coerced into a
+waitlist response. This indicates that the authenticated member
+has expressed interest in attending when space becomes available.</p>
+<p>OAuth authenticated applications should
+request the <a href="/meetup_api/auth/#rsvp_scope">rsvp</a>
+permission scope</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="agree_to_refund"><span class="">agree_to_refund</span></dt>
+    <dd class="rounded-all"><p>A boolean indicator used for Events with ticketing feeds to imply the Member has agreed to the Event's refund policy</p></dd>
+  
+    <dt class="align-right bold" title="answer_{qid}"><span class="">answer_{qid}</span></dt>
+    <dd class="rounded-all"><p>Answers to Event survey questions.
+Parameter names should have a suffix specifying the question's identifier.
+Answers may not be longer than 250 characters.</p></dd>
+  
+    <dt class="align-right bold" title="guests"><span class="">guests</span></dt>
+    <dd class="rounded-all"><p>The number of guests Member will be attending with.
+Events may define guest limits which is 2 by default</p></dd>
+  
+    <dt class="align-right bold" title="opt_to_pay"><span class="">opt_to_pay</span></dt>
+    <dd class="rounded-all"><p>A boolean indicator used for Events with ticketing fees to imply the Member has opted to pay as part of the RSVP request</p></dd>
+  
+    <dt class="align-right bold" title="pro_email_share_optin"><span class="">pro_email_share_optin</span></dt>
+    <dd class="rounded-all"><p>The authenticated Member's email opt in status. Supported values are either "true" or "false"</p></dd>
+  
+    <dt class="align-right bold" title="response"><span class="param_required">response</span></dt>
+    <dd class="rounded-all"><p>The authenticated Member's RSVP response. Supported values are either "yes" or "no"</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>If successful, this endpoint returns a 201 Created response. A 400 Bad request response will be
+returned if the authenticated Member can not attend this Meetup due any of the reasons defined in the
+<a href="/meetup_api/docs/:urlname/events/:event_id/rsvps/#errors">Errors</a> section below.</p>
+<p>In cases where a member successfully RSVP's yes to a ticketed Event before
+their payment is processed, the response will be returned as an HTTP 202 Accepted
+status.</p>
+  <dl>
+   
+    <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+    <dd class="rounded-all">
+    <p>Answers to event survey questions.
+Visible only to the posting member, hosts and the lead team</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="answer"><span class="">answer</span></dt>
+       <dd class="rounded-all">
+        <p>Answer text for question</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="question"><span class="">question</span></dt>
+       <dd class="rounded-all">
+        <p>Question text</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="question_id"><span class="">question_id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique number identifier for question</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>The last time this answer was updated</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="attendance_status"><span class="">attendance_status</span></dt>
+    <dd class="rounded-all">
+    <p>Represents an attendance status for this RSVP,
+returned when "attendance_status" is requested with the
+"fields" parameter.</p>
+<p>Value may be "attended" when marked attending,
+"absent" when marked absent or "noshow" when marked noshow</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Creation time of the RSVP, in milliseconds since the epoch.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="event"><span class="">event</span></dt>
+    <dd class="rounded-all">
+    <p>The Event associated with the RSVP</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>The Group associated with the RSVP</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric group ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used generate group duotone</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Status of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="guests"><span class="">guests</span></dt>
+    <dd class="rounded-all">
+    <p>Number of guests the RSVP'd member will be bringing</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>Member who RSVP'd</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Intro of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+       <dd class="rounded-all">
+        <p>Member's context within the event. Only returned in the context of an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host"><span class="">host</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator for whether this member is a host for the event</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self"><span class="">self</span></dt>
+       <dd class="rounded-all">
+        <p>Represents the authenticated member's relation to member.
+Returned with the "fields" request parameter includes "self" and
+the target member is not the authenticated member</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+            <dd class="rounded-all"><p>List of actions available for the authenticated member to perform.
+Currently only "message" is supported</p></dd>
+            
+            <dt class="align-right bold" title="blocks"><span class="">blocks</span></dt>
+            <dd class="rounded-all"><p>Boolean indication of whether or not the authenticated member blocks this member</p></dd>
+            
+            <dt class="align-right bold" title="common"><span class="">common</span></dt>
+            <dd class="rounded-all"><p>Information the authenticated member has in common with this member</p></dd>
+            
+            <dt class="align-right bold" title="friends"><span class="">friends</span></dt>
+            <dd class="rounded-all"><p>Boolean indication of whether or not the authenticated member is a friend of the member</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="pay_status"><span class="">pay_status</span></dt>
+    <dd class="rounded-all">
+    <p>The member's pay status for ticketed events returned with "pay_status"
+is requested with the "fields" parameter.</p>
+<p>Visible only to the member and the lead team.
+May be one of "refunded", "partial_refund", "refund_pending", "pending", "echeck_pending", "paid", "none", or "exempt"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="response"><span class="">response</span></dt>
+    <dd class="rounded-all">
+    <p>The response to the RSVP. May be "yes" or "no".</p>
+<p>In cases where an event is over capacity and the member has shown an intent to attend,
+response will be "waitlist" if the event has a waitlist.</p>
+<p>In cases of ticketed events, this may be "yes_pending_payment"
+for a "yes" response for a ticketed event with an unprocessed payment</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Last time the RSVP was updated, in milliseconds since the epoch.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+    <dd class="rounded-all">
+    <p>Venue of event RSVP is hosted at.
+Will be omitted when venue is not yet defined or organizer has chosen to hide it from non-members.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+       <dd class="rounded-all">
+        <p>Line 1 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+       <dd class="rounded-all">
+        <p>Line 2 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+       <dd class="rounded-all">
+        <p>Line 3 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="city"><span class="">city</span></dt>
+       <dd class="rounded-all">
+        <p>City of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country code of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric venue id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+       <dd class="rounded-all">
+        <p>The localized name of the venue's country</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Venue name</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+       <dd class="rounded-all">
+        <p>Phone number of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+       <dd class="rounded-all">
+        <p>true if the editor of the event altered the original venues pin location, false otherwise</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State of venue where available</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+       <dd class="rounded-all">
+        <p>ZIP code if, venue is in US or Canada</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+  
+  </dl>
+  
+  <h4 id="errors" class="rounded-all">Errors</h4>
+  <dl>
+  
+    <dt class="align-right bold"><span class="">answer_error</span></dt>
+    <dd><p>One or more of the provided answers were longer than 250 characters</p></dd>
+  
+    <dt class="align-right bold"><span class="">dues_required_error</span></dt>
+    <dd><p>Membership dues are awaiting payment</p></dd>
+  
+    <dt class="align-right bold"><span class="">event_past_error</span></dt>
+    <dd><p>The event is now in the past</p></dd>
+  
+    <dt class="align-right bold"><span class="">guests_error</span></dt>
+    <dd><p>A negative number of guests was provided</p></dd>
+  
+    <dt class="align-right bold"><span class="">invalid_event_error</span></dt>
+    <dd><p>Event was invalid</p></dd>
+  
+    <dt class="align-right bold"><span class="">invalid_response_error</span></dt>
+    <dd><p>Invalid RSVP response</p></dd>
+  
+    <dt class="align-right bold"><span class="">refund_agreement_error</span></dt>
+    <dd><p>Failed to agree to a paid Event's refund policy</p></dd>
+  
+    <dt class="align-right bold"><span class="">rsvp_closed_error</span></dt>
+    <dd><p>RSVPs have been closed for this event</p></dd>
+  
+    <dt class="align-right bold"><span class="">rsvp_error_error</span></dt>
+    <dd><p>Catch all generic error</p></dd>
+  
+    <dt class="align-right bold"><span class="">rsvper_not_authorized_error</span></dt>
+    <dd><p>Attempted to RSVP  another member on their behalf as a non organizer</p></dd>
+  
+    <dt class="align-right bold"><span class="">too_few_spots_error</span></dt>
+    <dd><p>Event capacity has been reached</p></dd>
+  
+    <dt class="align-right bold"><span class="">too_many_guests_error</span></dt>
+    <dd><p>More than the permitted number of guests for this event was provided</p></dd>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="list">
+  <h2>Event RSVP list</h2>
+  <div id="listuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/events/:event_id/rsvps
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Retrieves list of event RSVPs</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/events/:event_id/rsvps">Try it in the console</a></p>
+  <h3 id="listparams" class="rounded-all">Request Parameters</h3>
+  <div class="listparam-notes"><p>This endpoint returns an un-paginated list of RSVPs. Standard pagination parameters will have no effect</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="desc"><span class="">desc</span></dt>
+    <dd class="rounded-all"><p>Boolean value controling sort order of results. Defaults to false</p></dd>
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional fields to append to the response</p></dd>
+  
+    <dt class="align-right bold" title="order"><span class="">order</span></dt>
+    <dd class="rounded-all"><p>The sort order of returned RSVPs.
+Valid values include "name", "social", or "time".
+Defaults to "name"</p></dd>
+  
+    <dt class="align-right bold" title="response"><span class="">response</span></dt>
+    <dd class="rounded-all"><p>Filter returned list to one or more of the following RSVP responses.
+"yes" or "no". This defaults to "yes,no"</p></dd>
+  
+  </dl>
+  
+  <h3 id="listresponse" class="rounded-all">Response</h3>
+  <p>A list of RSVP objects encoded in JSON format</p>
+  <dl>
+   
+    <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+    <dd class="rounded-all">
+    <p>Answers to event survey questions.
+Visible only to the posting member, hosts and the lead team</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="answer"><span class="">answer</span></dt>
+       <dd class="rounded-all">
+        <p>Answer text for question</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="question"><span class="">question</span></dt>
+       <dd class="rounded-all">
+        <p>Question text</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="question_id"><span class="">question_id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique number identifier for question</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>The last time this answer was updated</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="attendance_status"><span class="">attendance_status</span></dt>
+    <dd class="rounded-all">
+    <p>Represents an attendance status for this RSVP,
+returned when "attendance_status" is requested with the
+"fields" parameter.</p>
+<p>Value may be "attended" when marked attending,
+"absent" when marked absent or "noshow" when marked noshow</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Creation time of the RSVP, in milliseconds since the epoch.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="event"><span class="">event</span></dt>
+    <dd class="rounded-all">
+    <p>The Event associated with the RSVP</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>The Group associated with the RSVP</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric group ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used generate group duotone</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Status of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="guests"><span class="">guests</span></dt>
+    <dd class="rounded-all">
+    <p>Number of guests the RSVP'd member will be bringing</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>Member who RSVP'd</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Intro of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+       <dd class="rounded-all">
+        <p>Member's context within the event. Only returned in the context of an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host"><span class="">host</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator for whether this member is a host for the event</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self"><span class="">self</span></dt>
+       <dd class="rounded-all">
+        <p>Represents the authenticated member's relation to member.
+Returned with the "fields" request parameter includes "self" and
+the target member is not the authenticated member</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+            <dd class="rounded-all"><p>List of actions available for the authenticated member to perform.
+Currently only "message" is supported</p></dd>
+            
+            <dt class="align-right bold" title="blocks"><span class="">blocks</span></dt>
+            <dd class="rounded-all"><p>Boolean indication of whether or not the authenticated member blocks this member</p></dd>
+            
+            <dt class="align-right bold" title="common"><span class="">common</span></dt>
+            <dd class="rounded-all"><p>Information the authenticated member has in common with this member</p></dd>
+            
+            <dt class="align-right bold" title="friends"><span class="">friends</span></dt>
+            <dd class="rounded-all"><p>Boolean indication of whether or not the authenticated member is a friend of the member</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="pay_status"><span class="">pay_status</span></dt>
+    <dd class="rounded-all">
+    <p>The member's pay status for ticketed events returned with "pay_status"
+is requested with the "fields" parameter.</p>
+<p>Visible only to the member and the lead team.
+May be one of "refunded", "partial_refund", "refund_pending", "pending", "echeck_pending", "paid", "none", or "exempt"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="response"><span class="">response</span></dt>
+    <dd class="rounded-all">
+    <p>The response to the RSVP. May be "yes" or "no".</p>
+<p>In cases where an event is over capacity and the member has shown an intent to attend,
+response will be "waitlist" if the event has a waitlist.</p>
+<p>In cases of ticketed events, this may be "yes_pending_payment"
+for a "yes" response for a ticketed event with an unprocessed payment</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Last time the RSVP was updated, in milliseconds since the epoch.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+    <dd class="rounded-all">
+    <p>Venue of event RSVP is hosted at.
+Will be omitted when venue is not yet defined or organizer has chosen to hide it from non-members.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+       <dd class="rounded-all">
+        <p>Line 1 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+       <dd class="rounded-all">
+        <p>Line 2 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+       <dd class="rounded-all">
+        <p>Line 3 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="city"><span class="">city</span></dt>
+       <dd class="rounded-all">
+        <p>City of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country code of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric venue id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+       <dd class="rounded-all">
+        <p>The localized name of the venue's country</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Venue name</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+       <dd class="rounded-all">
+        <p>Phone number of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+       <dd class="rounded-all">
+        <p>true if the editor of the event altered the original venues pin location, false otherwise</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State of venue where available</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+       <dd class="rounded-all">
+        <p>ZIP code if, venue is in US or Canada</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_events_:event_id_rsvps_close.html
+++ b/test/data/_:urlname_events_:event_id_rsvps_close.html
@@ -1,0 +1,68 @@
+
+        
+
+<div id="">
+  <h2>Close Rsvps</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname/events/:event_id/rsvps/close
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">event_management</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Closes rsvps for an event</p>
+  </div>
+  
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>Valid path parameters for <strong>:urlname</strong> and <strong>:event_id</strong> are required.</p>
+<p>Only event hosts and members of the lead team may close rsvps.</p>
+<p>OAuth authenticated applications should request the <a href="/meetup_api/auth/#event_management_scope">event_management</a> OAuth scope.</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>A successful request will return a 204 response.</p>
+  <dl>
+  
+  </dl>
+  
+  <h4 id="errors" class="rounded-all">Errors</h4>
+  <dl>
+  
+    <dt class="align-right bold"><span class="">closed_error</span></dt>
+    <dd><p>If you are closing rsvps, then you cannot set an rsvp deadline</p></dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_events_:event_id_rsvps_open.html
+++ b/test/data/_:urlname_events_:event_id_rsvps_open.html
@@ -1,0 +1,60 @@
+
+        
+
+<div id="">
+  <h2>Open Rsvps</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname/events/:event_id/rsvps/open
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">event_management</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Opens rsvps for an event</p>
+  </div>
+  
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>Valid path parameters for <strong>:urlname</strong> and <strong>:event_id</strong> are required.</p>
+<p>Only event hosts and members of the lead team may open rsvps.</p>
+<p>OAuth authenticated applications should request the <a href="/meetup_api/auth/#event_management_scope">event_management</a> OAuth scope.</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>A successful request will return a 204 response.</p>
+  <dl>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_events_:id.html
+++ b/test/data/_:urlname_events_:id.html
@@ -1,0 +1,2958 @@
+
+        
+
+<div id="edit">
+  <h2>Update Event</h2>
+  <div id="edituri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">PATCH</strong> /:urlname/events/:id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">event_management</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Updates an existing Meetup group event's details</p>
+  </div>
+  
+  <h3 id="editparams" class="rounded-all">Request Parameters</h3>
+  <div class="editparam-notes"><p>Valid path parameters for <strong>:urlname</strong> and event <strong>:id</strong> are required.</p>
+<p>Event descriptions only support a subset of HTML. Please see the <a href="/meetup_api/docs/:urlname/events/#createparams">Event Create</a> 
+documentation for more information.</p>
+<p>OAuth authenticated applications should request the <a href="/meetup_api/auth/#event_management_scope">event_management</a> OAuth scope.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="announce"><span class="">announce</span></dt>
+    <dd class="rounded-all"><p>Boolean value indicating whether or not Meetup should announce this event to group members. This defaults to false.</p></dd>
+  
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all"><p>String setting the description of the event, in simple HTML format. May not be longer than 50000 characters. Use an empty string to remove the existing description.</p></dd>
+  
+    <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+    <dd class="rounded-all"><p>Positive long representing event duration in milliseconds. Use 0 to remove existing duration.</p></dd>
+  
+    <dt class="align-right bold" title="event_hosts"><span class="">event_hosts</span></dt>
+    <dd class="rounded-all"><p>String containing up to 5 comma-separated valid member ids for members who will be hosts of the event.</p></dd>
+  
+    <dt class="align-right bold" title="featured_photo_id"><span class="">featured_photo_id</span></dt>
+    <dd class="rounded-all"><p>Positive integer representing a numeric identifier for a photo, which must be one associated with this group. Use 0 to remove the existing photo.</p></dd>
+  
+    <dt class="align-right bold" title="guest_limit"><span class="">guest_limit</span></dt>
+    <dd class="rounded-all"><p>Positive integer representing the number of guests that members may include in their RSVP, 0 inclusive. Previously RSVP'd guests will remain unaffected if the value is reduced.</p></dd>
+  
+    <dt class="align-right bold" title="how_to_find_us"><span class="">how_to_find_us</span></dt>
+    <dd class="rounded-all"><p>String setting the description for the location of the host(s) at the event venue. Use an empty string to remove the existing description. * For <strong>online events</strong> this field is used for the <strong>event's url</strong>.</p></dd>
+  
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all"><p>Float representing adjusted venue latitude. This can only be set if lon is included as well.</p></dd>
+  
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all"><p>Float representing adjusted venue longitude. This can only be set if lat is included as well.</p></dd>
+  
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all"><p>String setting the name of the event. Must be at least 1 character and may not be longer than 80 characters.</p></dd>
+  
+    <dt class="align-right bold" title="publish_status"><span class="">publish_status</span></dt>
+    <dd class="rounded-all"><p>String indicating whether an event will be published to the group or as a draft visible only to the leadership team. If editing a draft event, "published" will publish the event. That is the only valid use of this field when editing an event.</p></dd>
+  
+    <dt class="align-right bold" title="question"><span class="">question</span></dt>
+    <dd class="rounded-all"><p>String setting or replacing the RSVP survey question for the event. May not be longer than 250 characters. Use an empty string to remove the existing question.</p></dd>
+  
+    <dt class="align-right bold" title="rsvp_close_time"><span class="">rsvp_close_time</span></dt>
+    <dd class="rounded-all"><p>Positive long representing the time before which members will be allowed to RSVP to the event in milliseconds since the epoch. Use 0 to remove the existing RSVP close time restriction. This can only be set if there is a start time for the event.</p></dd>
+  
+    <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+    <dd class="rounded-all"><p>Positive integer representing total number of RSVP slots available for the event. Use 0 to remove existing limit. Previously RSVP'd guests will remain unaffected if the value is reduced.</p></dd>
+  
+    <dt class="align-right bold" title="rsvp_open_time"><span class="">rsvp_open_time</span></dt>
+    <dd class="rounded-all"><p>Positive long representing the time after which members will be allowed to RSVP to the event in milliseconds since the epoch. Use 0 to remove the existing RSVP open time restriction. This can only be set if there is a start time for the event.</p></dd>
+  
+    <dt class="align-right bold" title="time"><span class="">time</span></dt>
+    <dd class="rounded-all"><p>Positive long representing event start time in milliseconds since the epoch.</p></dd>
+  
+    <dt class="align-right bold" title="venue_id"><span class="">venue_id</span></dt>
+    <dd class="rounded-all"><p>Positive integer representing a numeric identifier for a venue. Use 0 to remove existing venue. This will override any latitude/longitude values that have previously been set. <strong>For online events use the string alias 'online'</strong>.</p></dd>
+  
+    <dt class="align-right bold" title="venue_visibility"><span class="">venue_visibility</span></dt>
+    <dd class="rounded-all"><p>String indicating whether the event venue and host location description will be visible to non-members of the hosting group. May be one of "public" or "members".</p></dd>
+  
+  </dl>
+  
+  <h3 id="editresponse" class="rounded-all">Response</h3>
+  <p>A successful request will return a 200 response with a body including the updated event information</p>
+  <dl>
+   
+    <dt class="align-right bold" title="attendance_count"><span class="">attendance_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of all members marked as attended, yes RSVPs that were not changed by attendance and their guests</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="attendance_sample"><span class="">attendance_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection of members marked as attended and yes RSVPs that were not changed by attendance</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="attendee_sample"><span class="">attendee_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection of attendance records of members marked as attended and yes RSVPs that were not changed by attendance. For upcoming events, this represents collection of yes RSVPs</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="comment_count"><span class="">comment_count</span></dt>
+    <dd class="rounded-all">
+    <p>An aggregate count of all comments and replies for a given event, returned when fields request parameter value includes 'comment_count'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Creation time of the event, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+    <dd class="rounded-all">
+    <p>Is event date matches the series pattern</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the event in HTML. Email addresses and phone numbers will be masked for non-members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description_images"><span class="">description_images</span></dt>
+    <dd class="rounded-all">
+    <p>A list of image urls included in the event description.  returned when "fields" request parameter value contains "description_images, only supported for GET /event/:id currently"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+    <dd class="rounded-all">
+    <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="event_hosts"><span class="">event_hosts</span></dt>
+    <dd class="rounded-all">
+    <p>List of members hosting the event, returned when fields request parameter value includes 'event_hosts'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="host_count"><span class="">host_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of times member hosted for group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="intro"><span class="">intro</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's introduction</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_date"><span class="">join_date</span></dt>
+       <dd class="rounded-all">
+        <p>Group join date in milliseconds since epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's name</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo if one exists</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="featured"><span class="">featured</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean indicator of whether or not a given event is featured, returned when fields request parameter value includes 'featured'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="featured_photo"><span class="">featured_photo</span></dt>
+    <dd class="rounded-all">
+    <p>A featured photo for this event, returned when the 'fields' request paramater includes 'featured_photo'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+    <dd class="rounded-all">
+    <p>Ticketing fee information for events that support payments</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+       <dd class="rounded-all">
+        <p>Amount of the fee</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+       <dd class="rounded-all">
+        <p>Currency accepted for fee</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="description"><span class="">description</span></dt>
+       <dd class="rounded-all">
+        <p>Fee description, typically "per-person"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="label"><span class="">label</span></dt>
+       <dd class="rounded-all">
+        <p>Label for fee, typically "Price"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="required"><span class="">required</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean flag indicating if this fee is required to RSVP</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee_options"><span class="">fee_options</span></dt>
+    <dd class="rounded-all">
+    <p>Payment options for event ticketing, returned when the 'fields' request parameter value includes 'fee_options'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currencies"><span class="">currencies</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable currencies for the payment method specified by type</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="code"><span class="">code</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="default"><span class="">default</span></dt>
+            <dd class="rounded-all"><p>A boolean set to true if the currency is the group's default currency, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="is_setup"><span class="">is_setup</span></dt>
+       <dd class="rounded-all">
+        <p>A boolean set to true if the payment method specified by 'type' is set up for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="setup_link"><span class="">setup_link</span></dt>
+       <dd class="rounded-all">
+        <p>The URL for setting up the payment method specified by 'type'. This is returned if the payment method specified by 'type' is not set up for the group and the member has the permission to set it up</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of Set(stripe, wepay, paypal, none, cash)</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>Information about group hosting the event</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="category"><span class="">category</span></dt>
+       <dd class="rounded-all">
+        <p>Category group belongs to, returned when fields request parameter value includes 'group_category'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric category id</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the category</p></dd>
+            
+            <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+            <dd class="rounded-all"><p>String identifier of the category</p></dd>
+            
+            <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+            <dd class="rounded-all"><p>Name used for sorting</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric identifier for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_info"><span class="">join_info</span></dt>
+       <dd class="rounded-all">
+        <p>Lists any questions requested when joining and required fields. Returned with "fields" request parameter value includes "group_join_info"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="photo_req"><span class="">photo_req</span></dt>
+            <dd class="rounded-all"><p>true if required, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="questions"><span class="">questions</span></dt>
+            <dd class="rounded-all"><p>List of profile questions organizer would like new members to answer prior to joining</p></dd>
+            
+            <dt class="align-right bold" title="questions_req"><span class="">questions_req</span></dt>
+            <dd class="rounded-all"><p>true if required, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo, returned when fields request parameter value includes 'group_key_photo'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate group latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate group longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Membership dues information associated with hosting group, returned when fields request parameter value includes 'group_membership_dues'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency in which the fee is declared</p></dd>
+            
+            <dt class="align-right bold" title="dues_links"><span class="">dues_links</span></dt>
+            <dd class="rounded-all"><p>Links to dues management and checkout pages.</p></dd>
+            
+            <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+            <dd class="rounded-all"><p>Numeric fee value</p></dd>
+            
+            <dt class="align-right bold" title="fee_desc"><span class="">fee_desc</span></dt>
+            <dd class="rounded-all"><p>The interval at which dues must be paid. Possible values may include: "month", "year", "day", or "every other day"</p></dd>
+            
+            <dt class="align-right bold" title="methods"><span class="">methods</span></dt>
+            <dd class="rounded-all"><p>Methods of payments</p></dd>
+            
+            <dt class="align-right bold" title="reasons"><span class="">reasons</span></dt>
+            <dd class="rounded-all"><p>Array of reasons containing one or more of the following values compensate_organizer, cover_costs, encourage_engagement, improve_meetups, other, provide_supplies, reserve_fund</p></dd>
+            
+            <dt class="align-right bold" title="reasons_other"><span class="">reasons_other</span></dt>
+            <dd class="rounded-all"><p>An additional reason if specified.</p></dd>
+            
+            <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+            <dd class="rounded-all"><p>Conditions for refunds</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>true if dues are required</p></dd>
+            
+            <dt class="align-right bold" title="required_to"><span class="">required_to</span></dt>
+            <dd class="rounded-all"><p>If the dues are required this indicates what they are required for. Currently may only be 'join'</p></dd>
+            
+            <dt class="align-right bold" title="self_payment_required"><span class="">self_payment_required</span></dt>
+            <dd class="rounded-all"><p>Returns true if the authorized user is prevented from participating in the group until a payment is made</p></dd>
+            
+            <dt class="align-right bold" title="trial_days"><span class="">trial_days</span></dt>
+            <dd class="rounded-all"><p>When present, returns the number of days the group is offering a free trial period for to new members. When not present, this indicates that the group does not offer a trial membership period</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="meta_category"><span class="">meta_category</span></dt>
+       <dd class="rounded-all">
+        <p>The meta category of the group, if the group has one, returned when fields request parameter value inclues 'meta_category'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="best_topics"><span class="">best_topics</span></dt>
+            <dd class="rounded-all"><p>Represents the best topic matches for this category, returned when the "fields"
+request parameter value includes "best_topics"</p></dd>
+            
+            <dt class="align-right bold" title="category_ids"><span class="">category_ids</span></dt>
+            <dd class="rounded-all"><p>List of numeric category ids associated with this topic category</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic-category id</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic-category</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Photo representing this category</p></dd>
+            
+            <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+            <dd class="rounded-all"><p>Unique string identifier for this category</p></dd>
+            
+            <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+            <dd class="rounded-all"><p>Name used for sorting</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count"><span class="">past_event_count</span></dt>
+       <dd class="rounded-all">
+        <p>The number of past events belonging to the group, returned when "fields" includes "group_past_event_count"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Photo associated with group, returned when fields request parameter value includes 'group_photo'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used to generate group duotone, returned when fields request parameter value includes 'group_photo_gradient'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="pro_network"><span class="">pro_network</span></dt>
+       <dd class="rounded-all">
+        <p>Information on group's Pro organization, returned when "fields" request parameter value includes "group_pro_network"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="region"><span class="">region</span></dt>
+       <dd class="rounded-all">
+        <p>Language and region of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self"><span class="">self</span></dt>
+       <dd class="rounded-all">
+        <p>Information pertaining to the authenticated member with respect to the group, returned when fields request parameter value includes 'group_self_profile', 'group_self_actions', 'group_self_membership_dues', or 'group_self_status'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+            <dd class="rounded-all"><p>list of actions the authenticated member may perform, potentially "event_create": the ability to create new events, "event_draft": the ability to save new events as drafts, "role_assign": the ability to assign member roles, "edit": the ability to edit group settings, "member_approval": the ability to approve or decline member requests to join, or "subscription_upgrade": the ability to upgrade this group's subscription plan</p></dd>
+            
+            <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+            <dd class="rounded-all"><p>Membership dues information associated with hosting group, returned when "fields" request parameter value includes "group_membership_dues" and group has dues</p></dd>
+            
+            <dt class="align-right bold" title="profile"><span class="">profile</span></dt>
+            <dd class="rounded-all"><p>Profile of the authenticated member</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Indicates the authorized user's membership with this group.</p>
+<p>Value may be one of "none", "pending", "pending_payment", "active", or "blocked"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+       <dd class="rounded-all">
+        <p>Timezone of group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>Topics related to the group, returned when fields request parameter value includes 'group_topics'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic id</p></dd>
+            
+            <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+            <dd class="rounded-all"><p>Language topic originates from</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic</p></dd>
+            
+            <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+            <dd class="rounded-all"><p>The unique keyword used to identify this topic</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric urlname identifier for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+       <dd class="rounded-all">
+        <p>Group visibility, returned when fields request parameter value includes 'group_visibility'. Value may be "public", "public_limited", or "members".</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="how_to_find_us"><span class="">how_to_find_us</span></dt>
+    <dd class="rounded-all">
+    <p>Additional information on how to find members at a venue when provided by an organizer, returned when fields request parameter value includes 'how_to_find_us'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>A unique alphanumeric identifier for event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+    <dd class="rounded-all">
+    <p>Is event happening online</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to event on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+    <dd class="rounded-all">
+    <p>The local date of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+    <dd class="rounded-all">
+    <p>The local time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="manual_attendance_count"><span class="">manual_attendance_count</span></dt>
+    <dd class="rounded-all">
+    <p>Manually entered total attendee headcount, if any exists</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of the event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+    <dd class="rounded-all">
+    <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+    <dd class="rounded-all">
+    <p>Information about photo uploads for this event, returned when fields request parameter value includes 'photo_album'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="event"><span class="">event</span></dt>
+       <dd class="rounded-all">
+        <p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric event ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of event</p></dd>
+            
+            <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of no RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="time"><span class="">time</span></dt>
+            <dd class="rounded-all"><p>UTC start time of the event, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+            <dd class="rounded-all"><p>The local offset from UTC time, in milliseconds</p></dd>
+            
+            <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+            <dd class="rounded-all"><p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of yes RSVPs</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for photo album</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of photos uploaded</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection of photos uploaded for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Album title</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_description"><span class="">plain_text_description</span></dt>
+    <dd class="rounded-all">
+    <p>Plain text version of the event description. Email addresses and photo numbers will be masked for non-members. Returned when "fields" request parameter value contains "plain_text_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_no_images_description"><span class="">plain_text_no_images_description</span></dt>
+    <dd class="rounded-all">
+    <p>Plain text version of the event description without images. Email addresses and photo numbers will be masked for non-members. Returned when "fields" request parameter value contains "plain_text_no_images_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+    <dd class="rounded-all">
+    <p>The number of "yes" RSVPS an event has capacity for</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_rules"><span class="">rsvp_rules</span></dt>
+    <dd class="rounded-all">
+    <p>Information about conditions that allow for member RSVPs, returned when fields request parameter value include 'rsvp_rules'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="close_time"><span class="">close_time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC time that RSVPs will no longer be accepted, though organizers may close RSVPs earlier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="closed"><span class="">closed</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean value indicating whether or not RSVPing was explicitly closed for the event.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="guest_limit"><span class="">guest_limit</span></dt>
+       <dd class="rounded-all">
+        <p>Number of guests members may include in their RSVP, 0 or more</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="open_time"><span class="">open_time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC time that members may begin to RSVP</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+       <dd class="rounded-all">
+        <p>The organizer-defined terms for refunds. If this is defined, you must provide the authenticated member a way to access this information before they can RSVP. They will need to agree to these terms before they RSVP</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="days"><span class="">days</span></dt>
+            <dd class="rounded-all"><p>if member_cancellation is present, it's relative to this many days before the event</p></dd>
+            
+            <dt class="align-right bold" title="notes"><span class="">notes</span></dt>
+            <dd class="rounded-all"><p>additional refund policy notes</p></dd>
+            
+            <dt class="align-right bold" title="policies"><span class="">policies</span></dt>
+            <dd class="rounded-all"><p>list of one or more of the following. 'no_refunds' if the organizer will not issue refunds', 'member_cancellation' if the organizer offers a refund for member cancellation, 'event_cancellation' if the organizer offers a refund if the event is canceled, 'event_rescheduled' if the organizer offers a refund when the event is rescheduled</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlisting"><span class="">waitlisting</span></dt>
+       <dd class="rounded-all">
+        <p>Wait list handling when RSVP limit is reached. Value may be one of 'auto', 'manual' or 'off'</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection RSVPs for members attending this event, returned when fields request parameter value includes 'rsvp_sample'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the RSVP, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="member"><span class="">member</span></dt>
+       <dd class="rounded-all">
+        <p>Member who RSVP'd</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+            <dd class="rounded-all"><p>Intro of member</p></dd>
+            
+            <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+            <dd class="rounded-all"><p>Member's context within the event. Only returned in the context of an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric member ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of member</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="self"><span class="">self</span></dt>
+            <dd class="rounded-all"><p>Represents the authenticated member's relation to member.
+Returned with the "fields" request parameter includes "self" and
+the target member is not the authenticated member</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time of the RSVP, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvpable"><span class="">rsvpable</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean value indicating whether or not the authenticated member can RSVP or join the waitlist when the event is full.
+Returned when the "fields" request parameter value
+includes "rsvpable"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvpable_after_join"><span class="">rsvpable_after_join</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean value indicating whether or not the authenticated member can RSVP
+after joining the hosting group.
+Returned when the "fields" request parameter
+includes "rsvpable_after_join"
+and the authenticated member is <em>not</em> a member of the
+group hosting this event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="saved"><span class="">saved</span></dt>
+    <dd class="rounded-all">
+    <p>Whether the authorized member has saved the event, returned when fields request parameter value includes 'saved'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>represents details particular to the authorized user, only present if requested and authenticated member is a member of the hosting group, returned when fields request parameter value includes 'self'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform, potentially one or more of the following</p>
+<p>"announce" to announce the event to the group's members</p>
+<p>"attendance" to view or take attendance for the event</p>
+<p>"copy" the ability to copy an event</p>
+<p>"comment" the ability to post a comment or reply</p>
+<p>"payments" the ability to mark members as paid if the event is ticketed</p>
+<p>"publish" to publish a draft event</p>
+<p>"edit" to edit the event information</p>
+<p>"edit_hosts" to edit the hosts for the event</p>
+<p>"email_attendees" the ability to email event attendees</p>
+<p>"delete" to delete the event</p>
+<p>"rsvp" to RSVP yes or no to the event</p>
+<p>"wait" to get on the waiting list (using the same RSVP methods).</p>
+<p>"dues" if an organizer requires membership dues to RSVP and the authorized
+ member has not paid theirs</p>
+<p>"upload_photo" the ability to upload a photo for the event</p>
+<p>"cancel" the ability to cancel the event</p>
+<p>"close" the ability to close the RSVPs for the event</p>
+<p>"open" the ability to open the RSVPs for the event</p>
+<p>"invite" the ability to invite someone for the event</p>
+<p>"download_attendees" the ability to download the attendees list for the event</p>
+<p>"take_attendance" the ability to take attendance for the event</p>
+<p>"delete_cancelled" the ability to delete the event if it is cancelled</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="pay_status"><span class="">pay_status</span></dt>
+       <dd class="rounded-all">
+        <p>The authenticated member's payment status. This may be one of 'none', 'paid', 'partially_paid', 'payment_pending', 'echeck_pending', 'refund_pending', 'partially_refunded', 'refunded'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The authenticated member's role in within the group, if any. This may be one of: Organizer, Assistant Organizer, Event Organizer, etc.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp"><span class="">rsvp</span></dt>
+       <dd class="rounded-all">
+        <p>Member's RSVP, if any</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+            <dd class="rounded-all"><p>List of answers to event survey questions asked when the member RSVP'd in the order asked, only available to organizers and assistant organizers</p></dd>
+            
+            <dt class="align-right bold" title="guests"><span class="">guests</span></dt>
+            <dd class="rounded-all"><p>Number of guests the RSVP'd member will be bringing</p></dd>
+            
+            <dt class="align-right bold" title="response"><span class="">response</span></dt>
+            <dd class="rounded-all"><p>May be "yes" or "no".</p>
+<p>In cases where an event is over capacity and the member has shown an intent to attend,
+response may be "waitlist" if the event has a waitlist.</p>
+<p>In cases of ticketed events, this may be "yes_pending_payment"
+for a "yes" response for a ticketed event with an unprocessed payment</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="series"><span class="">series</span></dt>
+    <dd class="rounded-all">
+    <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="description"><span class="">description</span></dt>
+       <dd class="rounded-all">
+        <p>Human displayable description of how often events in this series occur</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+       <dd class="rounded-all">
+        <p>Date when this series ends/ended, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the series</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+       <dd class="rounded-all">
+        <p>Returned for events that are part of a monthly recurring series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="day_of_week"><span class="">day_of_week</span></dt>
+            <dd class="rounded-all"><p>Integer value between 1-7 (Monday-Sunday) for the day of week the recurrence occurs upon</p></dd>
+            
+            <dt class="align-right bold" title="interval"><span class="">interval</span></dt>
+            <dd class="rounded-all"><p>Integer number of months between each recurrence</p></dd>
+            
+            <dt class="align-right bold" title="week_of_month"><span class="">week_of_month</span></dt>
+            <dd class="rounded-all"><p>Integer value between 1-5 representing the week number on which the event recurs. A value of 5 indicates the event recurs on the last week of every month</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+       <dd class="rounded-all">
+        <p>Date when this series begins/began, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the template event of the series</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+       <dd class="rounded-all">
+        <p>Returned for events that are part of a weekly recurring series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="days_of_week"><span class="">days_of_week</span></dt>
+            <dd class="rounded-all"><p>List of integers 1-7 (Monday-Sunday) of days of week recurrence occurs upon</p></dd>
+            
+            <dt class="align-right bold" title="interval"><span class="">interval</span></dt>
+            <dd class="rounded-all"><p>Integer number of weeks between each recurrence</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>A shortened link for the event on meetup.com, returned when fields request parameter value includes "short_link"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="simple_html_description"><span class="">simple_html_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the event, in simple HTML source format. If this event's description was saved in simple HTML format, the description field will be an HTML translation of this source. Returned when the "fields"' request parameter contains "simple_html_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>"cancelled", "upcoming", "past", "proposed", "suggested", or "draft"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+    <dd class="rounded-all">
+    <p>List of organizer-defined survey questions intended to be asked of RSVPing members. Returned when the "fields"' request parameter contains "answers"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric question identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="question"><span class="">question</span></dt>
+       <dd class="rounded-all">
+        <p>Question text</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="time"><span class="">time</span></dt>
+    <dd class="rounded-all">
+    <p>UTC start time of the event, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Last modified time for the event in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The local offset from UTC time, in milliseconds</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+    <dd class="rounded-all">
+    <p>The event venue, present only if selected and not hidden by an organizer</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+       <dd class="rounded-all">
+        <p>Line 1 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+       <dd class="rounded-all">
+        <p>Line 2 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+       <dd class="rounded-all">
+        <p>Line 3 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="city"><span class="">city</span></dt>
+       <dd class="rounded-all">
+        <p>City of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country code of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric venue id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+       <dd class="rounded-all">
+        <p>The localized name of the venue's country</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Venue name</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+       <dd class="rounded-all">
+        <p>Phone number of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+       <dd class="rounded-all">
+        <p>true if the editor of the event altered the original venues pin location, false otherwise</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State of venue where available</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+       <dd class="rounded-all">
+        <p>ZIP code if, venue is in US or Canada</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="venue_visibility"><span class="">venue_visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Represents who can see the venue with a potential value of "members" or "public", returned when fields request parameter value includes "venue_visibility" and the authenticated member is a member of the group hosting the event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Event visibility: "public", "public_limited", or "members". Events in private groups that do not expose limited information are visible only to that group's members and should not be made public.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of members on the waitlist, if one exists</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="web_actions"><span class="">web_actions</span></dt>
+    <dd class="rounded-all">
+    <p>Set of "Invite" and google/yahoo/ical/outlook "Add to calendar" web actions</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="why"><span class="">why</span></dt>
+    <dd class="rounded-all">
+    <p>We should do this because...</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of yes RSVPs including guests</p>
+    
+    </dd>
+  
+  </dl>
+  
+  <h4 id="editerrors" class="rounded-all">Errors</h4>
+  <dl>
+  
+    <dt class="align-right bold"><span class="">announce_error</span></dt>
+    <dd><p>Error announcing event</p></dd>
+  
+    <dt class="align-right bold"><span class="">description_error</span></dt>
+    <dd><p>Sorry, your Meetup description is too long</p></dd>
+  
+    <dt class="align-right bold"><span class="">duration_error</span></dt>
+    <dd><p>This event duration is invalid</p></dd>
+  
+    <dt class="align-right bold"><span class="">event_error</span></dt>
+    <dd><p>The id provided does not correspond to an event that can be edited</p></dd>
+  
+    <dt class="align-right bold"><span class="">event_hosts_error</span></dt>
+    <dd><p>One or more of the members provided are not active members of this group</p></dd>
+  
+    <dt class="align-right bold"><span class="">featured_photo_id_error</span></dt>
+    <dd><p>Something is wrong with the featured photo provided</p></dd>
+  
+    <dt class="align-right bold"><span class="">fee.amount_error</span></dt>
+    <dd><p>If the group is in the United States, the fee amount may not exceed 4999. Otherwise, the amount may not exceed 1000000</p></dd>
+  
+    <dt class="align-right bold"><span class="">fee.refund_policy_error</span></dt>
+    <dd><p>The fee refund policy may not exceed 250</p></dd>
+  
+    <dt class="align-right bold"><span class="">guest_limit_error</span></dt>
+    <dd><p>The guest limit is invalid</p></dd>
+  
+    <dt class="align-right bold"><span class="">how_to_find_us_error</span></dt>
+    <dd><p>Your "How to find us" description is too long</p></dd>
+  
+    <dt class="align-right bold"><span class="">lat_error</span></dt>
+    <dd><p>Your location is invalid</p></dd>
+  
+    <dt class="align-right bold"><span class="">local_date_error</span></dt>
+    <dd><p>If specifying a local date, your Meetup must also specify a local time</p></dd>
+  
+    <dt class="align-right bold"><span class="">local_time_error</span></dt>
+    <dd><p>If specifying a local time, your Meetup must also specify a local date</p></dd>
+  
+    <dt class="align-right bold"><span class="">name_error</span></dt>
+    <dd><p>A title is required to post your Meetup</p></dd>
+  
+    <dt class="align-right bold"><span class="">publish_status_error</span></dt>
+    <dd><p>You cannot publish a draft meetup with a start time in the past</p></dd>
+  
+    <dt class="align-right bold"><span class="">question_error</span></dt>
+    <dd><p>Something is not right with the RSVP question field</p></dd>
+  
+    <dt class="align-right bold"><span class="">rsvp_close_time_error</span></dt>
+    <dd><p>Your Meetup needs to have a start time before you can set an RSVP close time</p></dd>
+  
+    <dt class="align-right bold"><span class="">rsvp_limit_error</span></dt>
+    <dd><p>The RSVP limit is invalid</p></dd>
+  
+    <dt class="align-right bold"><span class="">rsvp_open_time_error</span></dt>
+    <dd><p>Please make sure your RSVPs are open before they close</p></dd>
+  
+    <dt class="align-right bold"><span class="">series.apply_to_error</span></dt>
+    <dd><p>A parameter was specified that is unsupported when editing a series</p></dd>
+  
+    <dt class="align-right bold"><span class="">series.weekly.days_of_week_error</span></dt>
+    <dd><p>This value must be one or more numbers between 1 and 7 separated by commas - representative of Monday through Sunday</p></dd>
+  
+    <dt class="align-right bold"><span class="">series_error</span></dt>
+    <dd><p>Something is wrong with the series</p></dd>
+  
+    <dt class="align-right bold"><span class="">time_error</span></dt>
+    <dd><p>There is a problem with the Meetup start time</p></dd>
+  
+    <dt class="align-right bold"><span class="">venue_id_error</span></dt>
+    <dd><p>Your location does not exist or can't be found</p></dd>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="delete">
+  <h2>Event Delete</h2>
+  <div id="deleteuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">DELETE</strong> /:urlname/events/:id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">event_management</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Cancels or removes an event from a groups calendar</p>
+  </div>
+  
+  <h3 id="deleteparams" class="rounded-all">Request Parameters</h3>
+  <div class="deleteparam-notes"><p>Valid path parameters for <strong>:urlname</strong> and event <strong>:id</strong> are required.</p>
+<p>Only organizers and the creator of the Meetup event may delete the event</p>
+<p>OAuth authenticated applications should request the <a href="/meetup_api/auth/#event_management_scope">event_management</a> OAuth scope.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="remove_from_calendar"><span class="">remove_from_calendar</span></dt>
+    <dd class="rounded-all"><p>Optional boolean parameter that, when set to true, fully deletes the event.
+If set to false, this operation cancels the event instead of completely removing it from the group's calendar.
+This defaults to true when not set explicitly.</p></dd>
+  
+    <dt class="align-right bold" title="update_series"><span class="">update_series</span></dt>
+    <dd class="rounded-all"><p>Optional boolean parameter that, when set to true, will update all future recurrences of this event if this event belongs to an event series.
+Requesting this for an event that doesn't belong to an active series will result in an error.
+You can detect an event's association with a series by sending fields=series when requesting event data.
+This defaults to false, when not set explicitly</p></dd>
+  
+  </dl>
+  
+  <h3 id="deleteresponse" class="rounded-all">Response</h3>
+  <p>A successful request will result in an HTTP 204 NoContent response</p>
+  <dl>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="get">
+  <h2>Get Event</h2>
+  <div id="geturi" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/events/:id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Fetches a Meetup Event by group urlname and event_id</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/events/:id">Try it in the console</a></p>
+  <h3 id="getparams" class="rounded-all">Request Parameters</h3>
+  <div class="getparam-notes"><p>The :urlname path element may be any valid group urlname.
+ The :id path element must be a valid alphanumeric Meetup Event identifier</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional fields to append to the response</p></dd>
+  
+  </dl>
+  
+  <h3 id="getresponse" class="rounded-all">Response</h3>
+  <p>Some Meetup group organizers may choose to limit the visibility of their group's content. In these cases,
+some fields may be omitted from the response if the authenticated member is not
+a member of the group hosting a given Event.</p>
+<p>Requesting an invalid event will result in a <code>404</code> not found error.</p>
+<p>Requesting Drafted event by user with non-leadership event will result in Forbidden <code>403</code></p>
+<p>Requesting a previously deleted event will result in a <code>410</code> Gone error</p>
+  <dl>
+   
+    <dt class="align-right bold" title="attendance_count"><span class="">attendance_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of all members marked as attended, yes RSVPs that were not changed by attendance and their guests</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="attendance_sample"><span class="">attendance_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection of members marked as attended and yes RSVPs that were not changed by attendance</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="attendee_sample"><span class="">attendee_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection of attendance records of members marked as attended and yes RSVPs that were not changed by attendance. For upcoming events, this represents collection of yes RSVPs</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="comment_count"><span class="">comment_count</span></dt>
+    <dd class="rounded-all">
+    <p>An aggregate count of all comments and replies for a given event, returned when fields request parameter value includes 'comment_count'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="comment_sample"><span class="">comment_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A sampling of recently past event comments.
+               Returned when the 'fields' request parameter
+               value contains 'comment_sample' and the group's
+               'visibility' setting permits it</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="comment"><span class="">comment</span></dt>
+       <dd class="rounded-all">
+        <p>The comment the member left for the event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Time the comment was posted in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Comment id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="in_reply_to"><span class="">in_reply_to</span></dt>
+       <dd class="rounded-all">
+        <p>The id of the comment a reply was in relation to</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="like_count"><span class="">like_count</span></dt>
+       <dd class="rounded-all">
+        <p>The number of likes the comment has</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="member"><span class="">member</span></dt>
+       <dd class="rounded-all">
+        <p>The member that made the comment.</p>
+<p>In cases where member has since left the group,
+this member may have an id of 0</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+            <dd class="rounded-all"><p>Intro of member</p></dd>
+            
+            <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+            <dd class="rounded-all"><p>Member's context within the event. Only returned in the context of an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric member ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of member</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="replies"><span class="">replies</span></dt>
+       <dd class="rounded-all">
+        <p>A list of replies, with the same structure as a comment.
+This field may be absent in cases where there are no replies</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self"><span class="">self</span></dt>
+       <dd class="rounded-all">
+        <p>Context for the authenticated member</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+            <dd class="rounded-all"><p>A list of actions the authenticated member may perform on the comment.</p>
+<p>Value may be one or more of the following:</p>
+<p><strong>flag_spam</strong> mark this comment as spam</p>
+<p><strong>delete</strong> delete this comment</p>
+<p><strong>unlike</strong> unlike this comment</p>
+<p><strong>like</strong> like this comment</p></dd>
+            
+            <dt class="align-right bold" title="liked"><span class="">liked</span></dt>
+            <dd class="rounded-all"><p>A boolean indicator of whether or not the authenticated member has liked the comment</p></dd>
+            
+            <dt class="align-right bold" title="notifications"><span class="">notifications</span></dt>
+            <dd class="rounded-all"><p>Indicator of whether or not the authenticated member may
+              receive notifications about related comments. May be one of 'on' or 'off'</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Creation time of the event, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+    <dd class="rounded-all">
+    <p>Is event date matches the series pattern</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the event in HTML. Email addresses and phone numbers will be masked for non-members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description_images"><span class="">description_images</span></dt>
+    <dd class="rounded-all">
+    <p>A list of image urls included in the event description.  returned when "fields" request parameter value contains "description_images, only supported for GET /event/:id currently"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+    <dd class="rounded-all">
+    <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="event_hosts"><span class="">event_hosts</span></dt>
+    <dd class="rounded-all">
+    <p>List of members hosting the event, returned when fields request parameter value includes 'event_hosts'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="host_count"><span class="">host_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of times member hosted for group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="intro"><span class="">intro</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's introduction</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_date"><span class="">join_date</span></dt>
+       <dd class="rounded-all">
+        <p>Group join date in milliseconds since epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's name</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo if one exists</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="featured"><span class="">featured</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean indicator of whether or not a given event is featured, returned when fields request parameter value includes 'featured'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="featured_photo"><span class="">featured_photo</span></dt>
+    <dd class="rounded-all">
+    <p>A featured photo for this event, returned when the 'fields' request paramater includes 'featured_photo'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+    <dd class="rounded-all">
+    <p>Ticketing fee information for events that support payments</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+       <dd class="rounded-all">
+        <p>Amount of the fee</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+       <dd class="rounded-all">
+        <p>Currency accepted for fee</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="description"><span class="">description</span></dt>
+       <dd class="rounded-all">
+        <p>Fee description, typically "per-person"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="label"><span class="">label</span></dt>
+       <dd class="rounded-all">
+        <p>Label for fee, typically "Price"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="required"><span class="">required</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean flag indicating if this fee is required to RSVP</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee_options"><span class="">fee_options</span></dt>
+    <dd class="rounded-all">
+    <p>Payment options for event ticketing, returned when the 'fields' request parameter value includes 'fee_options'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currencies"><span class="">currencies</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable currencies for the payment method specified by type</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="code"><span class="">code</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="default"><span class="">default</span></dt>
+            <dd class="rounded-all"><p>A boolean set to true if the currency is the group's default currency, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="is_setup"><span class="">is_setup</span></dt>
+       <dd class="rounded-all">
+        <p>A boolean set to true if the payment method specified by 'type' is set up for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="setup_link"><span class="">setup_link</span></dt>
+       <dd class="rounded-all">
+        <p>The URL for setting up the payment method specified by 'type'. This is returned if the payment method specified by 'type' is not set up for the group and the member has the permission to set it up</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of Set(stripe, wepay, paypal, none, cash)</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>Information about group hosting the event</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="category"><span class="">category</span></dt>
+       <dd class="rounded-all">
+        <p>Category group belongs to, returned when fields request parameter value includes 'group_category'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric category id</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the category</p></dd>
+            
+            <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+            <dd class="rounded-all"><p>String identifier of the category</p></dd>
+            
+            <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+            <dd class="rounded-all"><p>Name used for sorting</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric identifier for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_info"><span class="">join_info</span></dt>
+       <dd class="rounded-all">
+        <p>Lists any questions requested when joining and required fields. Returned with "fields" request parameter value includes "group_join_info"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="photo_req"><span class="">photo_req</span></dt>
+            <dd class="rounded-all"><p>true if required, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="questions"><span class="">questions</span></dt>
+            <dd class="rounded-all"><p>List of profile questions organizer would like new members to answer prior to joining</p></dd>
+            
+            <dt class="align-right bold" title="questions_req"><span class="">questions_req</span></dt>
+            <dd class="rounded-all"><p>true if required, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo, returned when fields request parameter value includes 'group_key_photo'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate group latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate group longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Membership dues information associated with hosting group, returned when fields request parameter value includes 'group_membership_dues'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency in which the fee is declared</p></dd>
+            
+            <dt class="align-right bold" title="dues_links"><span class="">dues_links</span></dt>
+            <dd class="rounded-all"><p>Links to dues management and checkout pages.</p></dd>
+            
+            <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+            <dd class="rounded-all"><p>Numeric fee value</p></dd>
+            
+            <dt class="align-right bold" title="fee_desc"><span class="">fee_desc</span></dt>
+            <dd class="rounded-all"><p>The interval at which dues must be paid. Possible values may include: "month", "year", "day", or "every other day"</p></dd>
+            
+            <dt class="align-right bold" title="methods"><span class="">methods</span></dt>
+            <dd class="rounded-all"><p>Methods of payments</p></dd>
+            
+            <dt class="align-right bold" title="reasons"><span class="">reasons</span></dt>
+            <dd class="rounded-all"><p>Array of reasons containing one or more of the following values compensate_organizer, cover_costs, encourage_engagement, improve_meetups, other, provide_supplies, reserve_fund</p></dd>
+            
+            <dt class="align-right bold" title="reasons_other"><span class="">reasons_other</span></dt>
+            <dd class="rounded-all"><p>An additional reason if specified.</p></dd>
+            
+            <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+            <dd class="rounded-all"><p>Conditions for refunds</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>true if dues are required</p></dd>
+            
+            <dt class="align-right bold" title="required_to"><span class="">required_to</span></dt>
+            <dd class="rounded-all"><p>If the dues are required this indicates what they are required for. Currently may only be 'join'</p></dd>
+            
+            <dt class="align-right bold" title="self_payment_required"><span class="">self_payment_required</span></dt>
+            <dd class="rounded-all"><p>Returns true if the authorized user is prevented from participating in the group until a payment is made</p></dd>
+            
+            <dt class="align-right bold" title="trial_days"><span class="">trial_days</span></dt>
+            <dd class="rounded-all"><p>When present, returns the number of days the group is offering a free trial period for to new members. When not present, this indicates that the group does not offer a trial membership period</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="meta_category"><span class="">meta_category</span></dt>
+       <dd class="rounded-all">
+        <p>The meta category of the group, if the group has one, returned when fields request parameter value inclues 'meta_category'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="best_topics"><span class="">best_topics</span></dt>
+            <dd class="rounded-all"><p>Represents the best topic matches for this category, returned when the "fields"
+request parameter value includes "best_topics"</p></dd>
+            
+            <dt class="align-right bold" title="category_ids"><span class="">category_ids</span></dt>
+            <dd class="rounded-all"><p>List of numeric category ids associated with this topic category</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic-category id</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic-category</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Photo representing this category</p></dd>
+            
+            <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+            <dd class="rounded-all"><p>Unique string identifier for this category</p></dd>
+            
+            <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+            <dd class="rounded-all"><p>Name used for sorting</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count"><span class="">past_event_count</span></dt>
+       <dd class="rounded-all">
+        <p>The number of past events belonging to the group, returned when "fields" includes "group_past_event_count"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Photo associated with group, returned when fields request parameter value includes 'group_photo'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used to generate group duotone, returned when fields request parameter value includes 'group_photo_gradient'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="pro_network"><span class="">pro_network</span></dt>
+       <dd class="rounded-all">
+        <p>Information on group's Pro organization, returned when "fields" request parameter value includes "group_pro_network"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="region"><span class="">region</span></dt>
+       <dd class="rounded-all">
+        <p>Language and region of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self"><span class="">self</span></dt>
+       <dd class="rounded-all">
+        <p>Information pertaining to the authenticated member with respect to the group, returned when fields request parameter value includes 'group_self_profile', 'group_self_actions', 'group_self_membership_dues', or 'group_self_status'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+            <dd class="rounded-all"><p>list of actions the authenticated member may perform, potentially "event_create": the ability to create new events, "event_draft": the ability to save new events as drafts, "role_assign": the ability to assign member roles, "edit": the ability to edit group settings, "member_approval": the ability to approve or decline member requests to join, or "subscription_upgrade": the ability to upgrade this group's subscription plan</p></dd>
+            
+            <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+            <dd class="rounded-all"><p>Membership dues information associated with hosting group, returned when "fields" request parameter value includes "group_membership_dues" and group has dues</p></dd>
+            
+            <dt class="align-right bold" title="profile"><span class="">profile</span></dt>
+            <dd class="rounded-all"><p>Profile of the authenticated member</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Indicates the authorized user's membership with this group.</p>
+<p>Value may be one of "none", "pending", "pending_payment", "active", or "blocked"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+       <dd class="rounded-all">
+        <p>Timezone of group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>Topics related to the group, returned when fields request parameter value includes 'group_topics'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic id</p></dd>
+            
+            <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+            <dd class="rounded-all"><p>Language topic originates from</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic</p></dd>
+            
+            <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+            <dd class="rounded-all"><p>The unique keyword used to identify this topic</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric urlname identifier for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+       <dd class="rounded-all">
+        <p>Group visibility, returned when fields request parameter value includes 'group_visibility'. Value may be "public", "public_limited", or "members".</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="how_to_find_us"><span class="">how_to_find_us</span></dt>
+    <dd class="rounded-all">
+    <p>Additional information on how to find members at a venue when provided by an organizer, returned when fields request parameter value includes 'how_to_find_us'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>A unique alphanumeric identifier for event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+    <dd class="rounded-all">
+    <p>Is event happening online</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to event on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+    <dd class="rounded-all">
+    <p>The local date of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+    <dd class="rounded-all">
+    <p>The local time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="manual_attendance_count"><span class="">manual_attendance_count</span></dt>
+    <dd class="rounded-all">
+    <p>Manually entered total attendee headcount, if any exists</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of the event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+    <dd class="rounded-all">
+    <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+    <dd class="rounded-all">
+    <p>Information about photo uploads for this event, returned when fields request parameter value includes 'photo_album'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="event"><span class="">event</span></dt>
+       <dd class="rounded-all">
+        <p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric event ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of event</p></dd>
+            
+            <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of no RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="time"><span class="">time</span></dt>
+            <dd class="rounded-all"><p>UTC start time of the event, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+            <dd class="rounded-all"><p>The local offset from UTC time, in milliseconds</p></dd>
+            
+            <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+            <dd class="rounded-all"><p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of yes RSVPs</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for photo album</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of photos uploaded</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection of photos uploaded for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Album title</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_description"><span class="">plain_text_description</span></dt>
+    <dd class="rounded-all">
+    <p>Plain text version of the event description. Email addresses and photo numbers will be masked for non-members. Returned when "fields" request parameter value contains "plain_text_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_no_images_description"><span class="">plain_text_no_images_description</span></dt>
+    <dd class="rounded-all">
+    <p>Plain text version of the event description without images. Email addresses and photo numbers will be masked for non-members. Returned when "fields" request parameter value contains "plain_text_no_images_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+    <dd class="rounded-all">
+    <p>The number of "yes" RSVPS an event has capacity for</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_rules"><span class="">rsvp_rules</span></dt>
+    <dd class="rounded-all">
+    <p>Information about conditions that allow for member RSVPs, returned when fields request parameter value include 'rsvp_rules'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="close_time"><span class="">close_time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC time that RSVPs will no longer be accepted, though organizers may close RSVPs earlier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="closed"><span class="">closed</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean value indicating whether or not RSVPing was explicitly closed for the event.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="guest_limit"><span class="">guest_limit</span></dt>
+       <dd class="rounded-all">
+        <p>Number of guests members may include in their RSVP, 0 or more</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="open_time"><span class="">open_time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC time that members may begin to RSVP</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+       <dd class="rounded-all">
+        <p>The organizer-defined terms for refunds. If this is defined, you must provide the authenticated member a way to access this information before they can RSVP. They will need to agree to these terms before they RSVP</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="days"><span class="">days</span></dt>
+            <dd class="rounded-all"><p>if member_cancellation is present, it's relative to this many days before the event</p></dd>
+            
+            <dt class="align-right bold" title="notes"><span class="">notes</span></dt>
+            <dd class="rounded-all"><p>additional refund policy notes</p></dd>
+            
+            <dt class="align-right bold" title="policies"><span class="">policies</span></dt>
+            <dd class="rounded-all"><p>list of one or more of the following. 'no_refunds' if the organizer will not issue refunds', 'member_cancellation' if the organizer offers a refund for member cancellation, 'event_cancellation' if the organizer offers a refund if the event is canceled, 'event_rescheduled' if the organizer offers a refund when the event is rescheduled</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlisting"><span class="">waitlisting</span></dt>
+       <dd class="rounded-all">
+        <p>Wait list handling when RSVP limit is reached. Value may be one of 'auto', 'manual' or 'off'</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection RSVPs for members attending this event, returned when fields request parameter value includes 'rsvp_sample'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the RSVP, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="member"><span class="">member</span></dt>
+       <dd class="rounded-all">
+        <p>Member who RSVP'd</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+            <dd class="rounded-all"><p>Intro of member</p></dd>
+            
+            <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+            <dd class="rounded-all"><p>Member's context within the event. Only returned in the context of an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric member ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of member</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="self"><span class="">self</span></dt>
+            <dd class="rounded-all"><p>Represents the authenticated member's relation to member.
+Returned with the "fields" request parameter includes "self" and
+the target member is not the authenticated member</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time of the RSVP, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvpable"><span class="">rsvpable</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean value indicating whether or not the authenticated member can RSVP or join the waitlist when the event is full.
+Returned when the "fields" request parameter value
+includes "rsvpable"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvpable_after_join"><span class="">rsvpable_after_join</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean value indicating whether or not the authenticated member can RSVP
+after joining the hosting group.
+Returned when the "fields" request parameter
+includes "rsvpable_after_join"
+and the authenticated member is <em>not</em> a member of the
+group hosting this event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="saved"><span class="">saved</span></dt>
+    <dd class="rounded-all">
+    <p>Whether the authorized member has saved the event, returned when fields request parameter value includes 'saved'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>represents details particular to the authorized user, only present if requested and authenticated member is a member of the hosting group, returned when fields request parameter value includes 'self'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform, potentially one or more of the following</p>
+<p>"announce" to announce the event to the group's members</p>
+<p>"attendance" to view or take attendance for the event</p>
+<p>"copy" the ability to copy an event</p>
+<p>"comment" the ability to post a comment or reply</p>
+<p>"payments" the ability to mark members as paid if the event is ticketed</p>
+<p>"publish" to publish a draft event</p>
+<p>"edit" to edit the event information</p>
+<p>"edit_hosts" to edit the hosts for the event</p>
+<p>"email_attendees" the ability to email event attendees</p>
+<p>"delete" to delete the event</p>
+<p>"rsvp" to RSVP yes or no to the event</p>
+<p>"wait" to get on the waiting list (using the same RSVP methods).</p>
+<p>"dues" if an organizer requires membership dues to RSVP and the authorized
+ member has not paid theirs</p>
+<p>"upload_photo" the ability to upload a photo for the event</p>
+<p>"cancel" the ability to cancel the event</p>
+<p>"close" the ability to close the RSVPs for the event</p>
+<p>"open" the ability to open the RSVPs for the event</p>
+<p>"invite" the ability to invite someone for the event</p>
+<p>"download_attendees" the ability to download the attendees list for the event</p>
+<p>"take_attendance" the ability to take attendance for the event</p>
+<p>"delete_cancelled" the ability to delete the event if it is cancelled</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="pay_status"><span class="">pay_status</span></dt>
+       <dd class="rounded-all">
+        <p>The authenticated member's payment status. This may be one of 'none', 'paid', 'partially_paid', 'payment_pending', 'echeck_pending', 'refund_pending', 'partially_refunded', 'refunded'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The authenticated member's role in within the group, if any. This may be one of: Organizer, Assistant Organizer, Event Organizer, etc.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp"><span class="">rsvp</span></dt>
+       <dd class="rounded-all">
+        <p>Member's RSVP, if any</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+            <dd class="rounded-all"><p>List of answers to event survey questions asked when the member RSVP'd in the order asked, only available to organizers and assistant organizers</p></dd>
+            
+            <dt class="align-right bold" title="guests"><span class="">guests</span></dt>
+            <dd class="rounded-all"><p>Number of guests the RSVP'd member will be bringing</p></dd>
+            
+            <dt class="align-right bold" title="response"><span class="">response</span></dt>
+            <dd class="rounded-all"><p>May be "yes" or "no".</p>
+<p>In cases where an event is over capacity and the member has shown an intent to attend,
+response may be "waitlist" if the event has a waitlist.</p>
+<p>In cases of ticketed events, this may be "yes_pending_payment"
+for a "yes" response for a ticketed event with an unprocessed payment</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="series"><span class="">series</span></dt>
+    <dd class="rounded-all">
+    <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="description"><span class="">description</span></dt>
+       <dd class="rounded-all">
+        <p>Human displayable description of how often events in this series occur</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+       <dd class="rounded-all">
+        <p>Date when this series ends/ended, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the series</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+       <dd class="rounded-all">
+        <p>Returned for events that are part of a monthly recurring series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="day_of_week"><span class="">day_of_week</span></dt>
+            <dd class="rounded-all"><p>Integer value between 1-7 (Monday-Sunday) for the day of week the recurrence occurs upon</p></dd>
+            
+            <dt class="align-right bold" title="interval"><span class="">interval</span></dt>
+            <dd class="rounded-all"><p>Integer number of months between each recurrence</p></dd>
+            
+            <dt class="align-right bold" title="week_of_month"><span class="">week_of_month</span></dt>
+            <dd class="rounded-all"><p>Integer value between 1-5 representing the week number on which the event recurs. A value of 5 indicates the event recurs on the last week of every month</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+       <dd class="rounded-all">
+        <p>Date when this series begins/began, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the template event of the series</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+       <dd class="rounded-all">
+        <p>Returned for events that are part of a weekly recurring series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="days_of_week"><span class="">days_of_week</span></dt>
+            <dd class="rounded-all"><p>List of integers 1-7 (Monday-Sunday) of days of week recurrence occurs upon</p></dd>
+            
+            <dt class="align-right bold" title="interval"><span class="">interval</span></dt>
+            <dd class="rounded-all"><p>Integer number of weeks between each recurrence</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>A shortened link for the event on meetup.com, returned when fields request parameter value includes "short_link"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="simple_html_description"><span class="">simple_html_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the event, in simple HTML source format. If this event's description was saved in simple HTML format, the description field will be an HTML translation of this source. Returned when the "fields"' request parameter contains "simple_html_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>"cancelled", "upcoming", "past", "proposed", "suggested", or "draft"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+    <dd class="rounded-all">
+    <p>List of organizer-defined survey questions intended to be asked of RSVPing members. Returned when the "fields"' request parameter contains "answers"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric question identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="question"><span class="">question</span></dt>
+       <dd class="rounded-all">
+        <p>Question text</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="time"><span class="">time</span></dt>
+    <dd class="rounded-all">
+    <p>UTC start time of the event, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Last modified time for the event in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The local offset from UTC time, in milliseconds</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+    <dd class="rounded-all">
+    <p>The event venue, present only if selected and not hidden by an organizer</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+       <dd class="rounded-all">
+        <p>Line 1 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+       <dd class="rounded-all">
+        <p>Line 2 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+       <dd class="rounded-all">
+        <p>Line 3 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="city"><span class="">city</span></dt>
+       <dd class="rounded-all">
+        <p>City of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country code of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric venue id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+       <dd class="rounded-all">
+        <p>The localized name of the venue's country</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Venue name</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+       <dd class="rounded-all">
+        <p>Phone number of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+       <dd class="rounded-all">
+        <p>true if the editor of the event altered the original venues pin location, false otherwise</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State of venue where available</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+       <dd class="rounded-all">
+        <p>ZIP code if, venue is in US or Canada</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="venue_visibility"><span class="">venue_visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Represents who can see the venue with a potential value of "members" or "public", returned when fields request parameter value includes "venue_visibility" and the authenticated member is a member of the group hosting the event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Event visibility: "public", "public_limited", or "members". Events in private groups that do not expose limited information are visible only to that group's members and should not be made public.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of members on the waitlist, if one exists</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="web_actions"><span class="">web_actions</span></dt>
+    <dd class="rounded-all">
+    <p>Set of "Invite" and google/yahoo/ical/outlook "Add to calendar" web actions</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="why"><span class="">why</span></dt>
+    <dd class="rounded-all">
+    <p>We should do this because...</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of yes RSVPs including guests</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_events_:id_attendance.html
+++ b/test/data/_:urlname_events_:id_attendance.html
@@ -1,0 +1,480 @@
+
+        
+
+<div id="list">
+  <h2>Attendance</h2>
+  <div id="listuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/events/:id/attendance
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Lists attendance records for Meetup events. Getting the list of attendance records for private groups is limited only to members of that group. The endpoint returns all members that have rsvped 'yes' or 'no' and members that were marked as either 'attended', 'noshow', or 'absent'</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/events/:id/attendance">Try it in the console</a></p>
+  <h3 id="listparams" class="rounded-all">Request Parameters</h3>
+  <div class="listparam-notes"><p>The :urlname path element may be any valid group urlname or domain name. The :id path element must be a valid alphanumeric Meetup event identifier</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="desc"><span class="">desc</span></dt>
+    <dd class="rounded-all"><p>Boolean value controlling sort order of results. Defaults to false</p></dd>
+  
+    <dt class="align-right bold" title="order"><span class="">order</span></dt>
+    <dd class="rounded-all"><p>The sort order of returned attendees.
+ The attendees are sorted in ascending order, use 'desc' to sort in descending order instead.
+ Valid values include "name", "social", or "time".
+ 'name' sorts alphabetically using the member's name. Attendees with no name will be moved to the bottom of the list, regardless of the value of 'desc'.
+ 'time' sorts using either the rsvp response time or the time the attendance was taken. If an attendee has both an rsvp status and attendance status we always use the time the attendance status was changed in the sort over the rsvp response time. Attendees with no rsvp response time or attendance time will be moved to the bottom of the list regardless of the 'desc' value.
+ 'social' sorts the attendees by the amount of friends and groups that they have in common with the authenticated member. If there is no authenticated member we default to 'name'.
+ Default sort is: name.</p></dd>
+  
+  </dl>
+  
+  <h3 id="listresponse" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="guests"><span class="">guests</span></dt>
+    <dd class="rounded-all">
+    <p>Number of guests when the attendance was taken on the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Unique identifier for the attendance</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>Member who RSVP'd</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Intro of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+       <dd class="rounded-all">
+        <p>Member's context within the event. Only returned in the context of an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host"><span class="">host</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator for whether this member is a host for the event</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="pay_status"><span class="">pay_status</span></dt>
+    <dd class="rounded-all">
+    <p>The member's pay status for ticketed events returned with "pay_status"
+is requested with the "fields" parameter.</p>
+<p>Visible only to the member and the lead team.
+May be one of "refunded", "partial_refund", "refund_pending", "pending", "echeck_pending", "paid", "none", or "exempt"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp"><span class="">rsvp</span></dt>
+    <dd class="rounded-all">
+    <p>RSVP, if member originally RSVP'd</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+       <dd class="rounded-all">
+        <p>Answers to event survey questions.
+Visible only to the posting member, hosts and the lead team</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="answer"><span class="">answer</span></dt>
+            <dd class="rounded-all"><p>Answer text for question</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+            <dt class="align-right bold" title="question_id"><span class="">question_id</span></dt>
+            <dd class="rounded-all"><p>Unique number identifier for question</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>The last time this answer was updated</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="guests"><span class="">guests</span></dt>
+       <dd class="rounded-all">
+        <p>Number of guests when the member rsvped</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique identifier for the rsvp</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="response"><span class="">response</span></dt>
+       <dd class="rounded-all">
+        <p>Member's original RSVP response. May be one of: 'yes', 'no', 'waitlist'. If there is no corresponding attendance status for the memer, only 'yes' and 'no' will be returned.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time of the attendance status, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>The member's attendance status. May be one of: 'attended', 'absent', 'noshow'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Last modified time of the attendance status, in milliseconds since the epoch</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="edit">
+  <h2>Attendance Taking</h2>
+  <div id="edituri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname/events/:id/attendance
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Takes member attendance for an event. Limited for use by administrative members.</p>
+  </div>
+  
+  <h3 id="editparams" class="rounded-all">Request Parameters</h3>
+  <div class="editparam-notes"><p>The :urlname path element may be any valid group urlname or domain name. The :id path element must be a valid alphanumeric Meetup event identifier. Highlighted fields are required.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="guests"><span class="">guests</span></dt>
+    <dd class="rounded-all"><p>The number of guests accompanying member. Maximum of guests allowed is 99.
+If the field is empty the guest count is either populated using the rsvp guest count or the guest count from the existing attendance status for the corresponding member.
+If no guest count is found it defaults to 0.</p></dd>
+  
+    <dt class="align-right bold" title="member"><span class="param_required">member</span></dt>
+    <dd class="rounded-all"><p>MemberId of member we are taking attendance on</p></dd>
+  
+    <dt class="align-right bold" title="status"><span class="param_required">status</span></dt>
+    <dd class="rounded-all"><p>An attendance status for the provided members. Must be one of: noshow, absent, attended</p></dd>
+  
+  </dl>
+  
+  <h3 id="editresponse" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="guests"><span class="">guests</span></dt>
+    <dd class="rounded-all">
+    <p>Number of guests when the attendance was taken on the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Unique identifier for the attendance</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>Member who RSVP'd</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Intro of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+       <dd class="rounded-all">
+        <p>Member's context within the event. Only returned in the context of an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host"><span class="">host</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator for whether this member is a host for the event</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="pay_status"><span class="">pay_status</span></dt>
+    <dd class="rounded-all">
+    <p>The member's pay status for ticketed events returned with "pay_status"
+is requested with the "fields" parameter.</p>
+<p>Visible only to the member and the lead team.
+May be one of "refunded", "partial_refund", "refund_pending", "pending", "echeck_pending", "paid", "none", or "exempt"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp"><span class="">rsvp</span></dt>
+    <dd class="rounded-all">
+    <p>RSVP, if member originally RSVP'd</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+       <dd class="rounded-all">
+        <p>Answers to event survey questions.
+Visible only to the posting member, hosts and the lead team</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="answer"><span class="">answer</span></dt>
+            <dd class="rounded-all"><p>Answer text for question</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+            <dt class="align-right bold" title="question_id"><span class="">question_id</span></dt>
+            <dd class="rounded-all"><p>Unique number identifier for question</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>The last time this answer was updated</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="guests"><span class="">guests</span></dt>
+       <dd class="rounded-all">
+        <p>Number of guests when the member rsvped</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique identifier for the rsvp</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="response"><span class="">response</span></dt>
+       <dd class="rounded-all">
+        <p>Member's original RSVP response. May be one of: 'yes', 'no', 'waitlist'. If there is no corresponding attendance status for the memer, only 'yes' and 'no' will be returned.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time of the attendance status, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>The member's attendance status. May be one of: 'attended', 'absent', 'noshow'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Last modified time of the attendance status, in milliseconds since the epoch</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_events_:id_payments.html
+++ b/test/data/_:urlname_events_:id_payments.html
@@ -1,0 +1,88 @@
+
+        
+
+<div id="">
+  <h2>Event Payments</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname/events/:id/payments
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Allows organizers of a group to note payments made by members for an event. This is the 'Mark Paid' feature seen in the RSVP listings on event details pages and affects the 'pay_status' response fields in the <a href="/meetup_api/docs/:urlname/events/:event_id/rsvps/#listresponse">/:urlname/events/:event_id/rsvps</a> for paid events</p>
+  </div>
+  
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>Only organizer may submit payment information for members and only one payment may be submitted for a member for a given event</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="amount"><span class="param_required">amount</span></dt>
+    <dd class="rounded-all"><p>The monetary amount of money the member submitted</p></dd>
+  
+    <dt class="align-right bold" title="member"><span class="param_required">member</span></dt>
+    <dd class="rounded-all"><p>Member Id of member who made a payment</p></dd>
+  
+    <dt class="align-right bold" title="paid_on"><span class="">paid_on</span></dt>
+    <dd class="rounded-all"><p>The time the payment was made in milliseconds from the epoc. Defaults to now</p></dd>
+  
+    <dt class="align-right bold" title="quantity"><span class="">quantity</span></dt>
+    <dd class="rounded-all"><p>The number of payments made. Defaults to 1</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="confirm_code"><span class="">confirm_code</span></dt>
+    <dd class="rounded-all">
+    <p>Confirmation code for the payment</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Unique identifier for the payment</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+  <h3 id="examples" class="rounded-all">Examples</h3>
+  <p>Collect a payment in my-group for event 123 by member 456</p>
+<pre><code>curl 'https://api.meetup.com/my-group/events/123/payments' \
+     -d 'key=ORG_API_KEY&amp;member=456&amp;amount=10.00'
+</code></pre>
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_member_approvals.html
+++ b/test/data/_:urlname_member_approvals.html
@@ -1,0 +1,168 @@
+
+        
+
+<div id="create">
+  <h2>Membership Approval</h2>
+  <div id="createuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname/member/approvals
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Approves one or more requests for group membership</p>
+  </div>
+  
+  <h3 id="createparams" class="rounded-all">Request Parameters</h3>
+  <div class="createparam-notes"><p>The :urlname path element may be any valid group urlname or domain name. If you need access to your group's welcome message, you can access it from the <a href="/meetup_api/docs/:urlname/#getresponse">/:urlname</a> groups method, providing a value of <code>welcome_message</code> for the fields parameter. To get a list of pending members, as an organizer, you can request the status <code>pending</code> in the <a href="/meetup_api/docs/:urlname/members/#listparams">/:urlname/members</a> method.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all"><p>Comma-delimited numeric pending member IDs. The maximum allowed is 200</p></dd>
+  
+    <dt class="align-right bold" title="send_copy"><span class="">send_copy</span></dt>
+    <dd class="rounded-all"><p>Optional boolean value indicating whether or not the org should receive a copy of the message sent to the approved members</p></dd>
+  
+    <dt class="align-right bold" title="welcome_message"><span class="">welcome_message</span></dt>
+    <dd class="rounded-all"><p>Optional message to send to the members being approved. If not provided, the groups default welcome message will be sent. Max message size is 2000</p></dd>
+  
+  </dl>
+  
+  <h3 id="createresponse" class="rounded-all">Response</h3>
+  <p>A successful request will result in a simple JSON-encoded message with an HTTP 200 response.</p>
+  <dl>
+  
+  </dl>
+  
+  <h4 id="createerrors" class="rounded-all">Errors</h4>
+  <dl>
+  
+    <dt class="align-right bold"><span class="">member_limit_error</span></dt>
+    <dd><p>returned when an attempt to approve members goes over the maximum number of active members for the group</p></dd>
+  
+    <dt class="align-right bold"><span class="">permission_error</span></dt>
+    <dd><p>returned when a non-organizer attempts to approve members</p></dd>
+  
+  </dl>
+  
+  
+  <h3 id="createexamples" class="rounded-all">Examples</h3>
+  <p>Approve requests for membership in your group</p>
+<pre><code>curl -H "Authorization: Bearer $OAUTH2_ACCESS_TOKEN" 'https://api.meetup.com/your-group/member/approvals' -d 'member=123,456'
+{"message":"ok"}
+</code></pre>
+<p>Members 123 and 456 will get an email notification</p>
+  
+</div>
+
+<div id="delete">
+  <h2>Membership Decline</h2>
+  <div id="deleteuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">DELETE</strong> /:urlname/member/approvals
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Declines one or more requests for group membership</p>
+  </div>
+  
+  <h3 id="deleteparams" class="rounded-all">Request Parameters</h3>
+  <div class="deleteparam-notes"><p>The :urlname path element may be any valid group urlname or domain name. To get a list of pending members, as an organizer, you can request the status <code>pending</code> in the <a href="/meetup_api/docs/:urlname/members/#listparams">/:urlname/members</a> method.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="anon"><span class="">anon</span></dt>
+    <dd class="rounded-all"><p>Optional Boolean value indicating whether the declining member's email address should be hidden in the resulting response. Default is true.</p></dd>
+  
+    <dt class="align-right bold" title="ban"><span class="">ban</span></dt>
+    <dd class="rounded-all"><p>Optional Boolean value indicating whether or not to ban the member in the future. Default is false</p></dd>
+  
+    <dt class="align-right bold" title="explanation"><span class="">explanation</span></dt>
+    <dd class="rounded-all"><p>Optional explanation to send to the members being declined. Max message size is 2000</p></dd>
+  
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all"><p>Comma-delimited numeric pending member IDs. The maximum allowed is 200</p></dd>
+  
+    <dt class="align-right bold" title="send_copy"><span class="">send_copy</span></dt>
+    <dd class="rounded-all"><p>Optional Boolean value indicating whether or not to send a copy to the member issuing the decline. Default is false</p></dd>
+  
+  </dl>
+  
+  <h3 id="deleteresponse" class="rounded-all">Response</h3>
+  <p>A successful request will result in a simple JSON-encoded message with an HTTP 200 response</p>
+  <dl>
+  
+  </dl>
+  
+  <h4 id="deleteerrors" class="rounded-all">Errors</h4>
+  <dl>
+  
+    <dt class="align-right bold"><span class="">permission_error</span></dt>
+    <dd><p>returned when a non-organizer attempts to decline members</p></dd>
+  
+  </dl>
+  
+  
+  <h3 id="deleteexamples" class="rounded-all">Examples</h3>
+  <p>Decline requests for membership in your group</p>
+<pre><code>curl -H "Authorization: Bearer $OAUTH2_ACCESS_TOKEN" -X DELETE 'https://api.meetup.com/your-group/member/approvals?member=123,456'
+{"message":"ok"}
+</code></pre>
+<p>Members 123 and 456 will get an email notification</p>
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_members.html
+++ b/test/data/_:urlname_members.html
@@ -1,0 +1,1830 @@
+
+        
+
+<div id="list">
+  <h2>Group Profile list</h2>
+  <div id="listuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/members
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Get a list of Meetup group members</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/members">Try it in the console</a></p>
+  <h3 id="listparams" class="rounded-all">Request Parameters</h3>
+  <div class="listparam-notes"><p>A valid <strong>:urlname</strong> path parameter is required</p>
+<p>This endpoint uses HTTP <a href="/meetup_api/docs/#v3_json">Link header based pagination</a>.</p>
+<p>This endpoint returns active members by default.
+Group organizers may request pending members using the 'status' request parameter</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="desc"><span class="">desc</span></dt>
+    <dd class="rounded-all"><p>Boolean value controling sort order of results.
+Currently this parameter is only supported for "joined"
+and "name" sorted results.
+Defaults to true</p></dd>
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional fields to append to the response</p></dd>
+  
+    <dt class="align-right bold" title="filter"><span class="">filter</span></dt>
+    <dd class="rounded-all"><p>May be set to 'stepup_eligible' to return only members eligible to step up as organizer</p></dd>
+  
+    <dt class="align-right bold" title="order"><span class="">order</span></dt>
+    <dd class="rounded-all"><p>Orders results according to definitions listed below. May be one of "interesting", "name", "joined", or "stepup_recommended"</p></dd>
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>Number of requested members to return. Defaults to 200</p></dd>
+  
+    <dt class="align-right bold" title="role"><span class="">role</span></dt>
+    <dd class="rounded-all"><p>May be set to "leads" to filter returned members on the lead team</p></dd>
+  
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of member statuses. Valid values include "active" or "pending".
+Defaults to "active". Organizers may request pending</p></dd>
+  
+  </dl>
+  
+  <h4 id="listordering">Ordering</h4>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold"><span class="">interesting</span></dt>
+    <dd class="rounded-all"><p>Order which may be interesting to the authorized member</p></dd>
+  
+    <dt class="align-right bold"><span class="">joined</span></dt>
+    <dd class="rounded-all"><p>Time member joined this group</p></dd>
+  
+    <dt class="align-right bold"><span class="">name</span></dt>
+    <dd class="rounded-all"><p>The name of the member</p></dd>
+  
+    <dt class="align-right bold"><span class="">stepup_recommended</span></dt>
+    <dd class="rounded-all"><p>Sorts by likelikhood to step up as organizer</p></dd>
+  
+  </dl>
+  
+  <h3 id="listresponse" class="rounded-all">Response</h3>
+  <p>Returns a list of profile objects encoded as JSON</p>
+  <dl>
+   
+    <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+    <dd class="rounded-all">
+    <p>Member bio. When profile does not belong to the authenticated member, this may be omitted if member opted to hide their bio from others</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="birthday"><span class="">birthday</span></dt>
+    <dd class="rounded-all">
+    <p>Returned only when the fields request parameter value includes 'birthday'
+and only for the authenticated member when defined</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="day"><span class="">day</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric day member was born. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="month"><span class="">month</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric month member was born. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="year"><span class="">year</span></dt>
+       <dd class="rounded-all">
+        <p>Year member was born</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country code associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="email"><span class="">email</span></dt>
+    <dd class="rounded-all">
+    <p>Member email address. Provided only if a profile belongs to the authenticated member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="gender"><span class="">gender</span></dt>
+    <dd class="rounded-all">
+    <p>Returned only when the fields request parameter value includes "gender"
+and only for the authenticated member.
+Value may be one of "female", "male", "none", or "other".
+This field may be absent where gender is not defined</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_profile"><span class="">group_profile</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup Group profile information.
+This field is only returned when profile is requested in group contexts</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+       <dd class="rounded-all">
+        <p>Array of answers to Group Profile questions</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="answer"><span class="">answer</span></dt>
+            <dd class="rounded-all"><p>Answer text</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+            <dt class="align-right bold" title="question_id"><span class="">question_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric question identifier</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>The time this member joined the Group, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>The group associated with this membership</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+            <dd class="rounded-all"><p>Group photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric group ID</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Who can join this group and how. One of "approval", "closed", or "open"</p></dd>
+            
+            <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+            <dd class="rounded-all"><p>Group primary photo</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+            <dd class="rounded-all"><p>Color combination used generate group duotone</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Status of the group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Urlname used to identify the group on meetup.com</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="intro"><span class="">intro</span></dt>
+       <dd class="rounded-all">
+        <p>Member intro, may be omitted if member opted to hide their intro from other members</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="link"><span class="">link</span></dt>
+       <dd class="rounded-all">
+        <p>Member profile link, provides a link to the members chapter profile</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the Group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Membership status in this Group.
+Value may be one of
+active, blocked, pending, pending_payment or none</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>The last time this member edited their Group profile, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+       <dd class="rounded-all">
+        <p>The last time this member visited the Group, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Unique numeric identifier for the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_pro_admin"><span class="">is_pro_admin</span></dt>
+    <dd class="rounded-all">
+    <p>Returns true if the member is an active admin of an active meetup pro network</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="joined"><span class="">joined</span></dt>
+    <dd class="rounded-all">
+    <p>Time member joined, represented as milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Geographic latitude associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of country associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Geographic longitude associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="messaging_pref"><span class="">messaging_pref</span></dt>
+    <dd class="rounded-all">
+    <p>The member's preference for being contacted from other members on the platform.
+Returned only when the fields request parameter value includes "messaging_pref".
+May be one of the following: "all_members", "groups_only", or "orgs_only"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Display name for the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="other_services"><span class="">other_services</span></dt>
+    <dd class="rounded-all">
+    <p>An object whose key's are the names of associated external
+networks and values are identities within those networks.
+The keys may be one of facebook, flickr, linkedin, tumblr or twitter.
+Returned only when "fields" request parameter value
+includes "other_services"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="identifier"><span class="">identifier</span></dt>
+       <dd class="rounded-all">
+        <p>A unique string identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="url"><span class="">url</span></dt>
+       <dd class="rounded-all">
+        <p>A url for this identity. May be the same as identifier in some cases</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+    <dd class="rounded-all">
+    <p>Member photo. May be absent if member has not chosen one.
+In group contexts, the Member's Group profile photo will be returned.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="privacy"><span class="">privacy</span></dt>
+    <dd class="rounded-all">
+    <p>Member's privacy preferences
+Returned only when the "fields" request parameter value includes "privacy"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="facebook"><span class="">facebook</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' of 'visible'.
+If absent, the member has not connected their Facebook account to Meetup</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible'</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Represents the authenticated member's relation to member.
+Returned when "fields" request parameter value includes "self" and
+the target member is not the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions available for the authenticated member to perform.
+Currently only "message" is supported</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="blocks"><span class="">blocks</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indication of whether or not the authenticated member blocks this member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="common"><span class="">common</span></dt>
+       <dd class="rounded-all">
+        <p>Information the authenticated member has in common with this member</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+            <dd class="rounded-all"><p>List of common groups</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="friends"><span class="">friends</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indication of whether or not the authenticated member is a friend of the member</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State associated with Member's location, where available</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>a string with one of the following values: {'active', 'prereg', 'unknown'}</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="create">
+  <h2>Group Join</h2>
+  <div id="createuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname/members
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">group_join</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>This method allows an authenticated member to join a group by creating a profile</p>
+  </div>
+  
+  <h3 id="createparams" class="rounded-all">Request Parameters</h3>
+  <div class="createparam-notes"><p>This method requires https and an HTTP POST. All required parameters must be supplied.
+An intro and answers to group profile questions may be required based for the group the member is joining.</p>
+<p>OAuth authenticated applications should
+request the <a href="/meetup_api/auth/#group_join_scope">group_join</a>
+permission scope</p>
+<p>To find out if a group requires an intro or answers to questions, query for the group
+through one of the groups methods providing setting the fields parameter to join_info and
+inspecting the join_info in the results.
+Answers to the questions must be named using the convention answer_{question_id}.</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="createresponse" class="rounded-all">Response</h3>
+  <p>A successful request will return a Profile with embedded group_profile.
+The group-specific information provided in this request should be visible there.</p>
+<p>Note that successful attempts to join groups that require organizer approval
+will require additional action taken by the organizer to complete your membership.
+You can inspect the group_profile.status field to know if you are active or pending.
+If the organizer declines your request they may optionally choose to ban you from future attempts to join</p>
+  <dl>
+   
+    <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+    <dd class="rounded-all">
+    <p>Member bio. When profile does not belong to the authenticated member, this may be omitted if member opted to hide their bio from others</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="birthday"><span class="">birthday</span></dt>
+    <dd class="rounded-all">
+    <p>Returned only when the fields request parameter value includes 'birthday'
+and only for the authenticated member when defined</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="day"><span class="">day</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric day member was born. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="month"><span class="">month</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric month member was born. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="year"><span class="">year</span></dt>
+       <dd class="rounded-all">
+        <p>Year member was born</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country code associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="email"><span class="">email</span></dt>
+    <dd class="rounded-all">
+    <p>Member email address. Provided only if a profile belongs to the authenticated member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="gender"><span class="">gender</span></dt>
+    <dd class="rounded-all">
+    <p>Returned only when the fields request parameter value includes "gender"
+and only for the authenticated member.
+Value may be one of "female", "male", "none", or "other".
+This field may be absent where gender is not defined</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_profile"><span class="">group_profile</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup Group profile information.
+This field is only returned when profile is requested in group contexts</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+       <dd class="rounded-all">
+        <p>Array of answers to Group Profile questions</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="answer"><span class="">answer</span></dt>
+            <dd class="rounded-all"><p>Answer text</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+            <dt class="align-right bold" title="question_id"><span class="">question_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric question identifier</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>The time this member joined the Group, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>The group associated with this membership</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+            <dd class="rounded-all"><p>Group photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric group ID</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Who can join this group and how. One of "approval", "closed", or "open"</p></dd>
+            
+            <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+            <dd class="rounded-all"><p>Group primary photo</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+            <dd class="rounded-all"><p>Color combination used generate group duotone</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Status of the group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Urlname used to identify the group on meetup.com</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="intro"><span class="">intro</span></dt>
+       <dd class="rounded-all">
+        <p>Member intro, may be omitted if member opted to hide their intro from other members</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="link"><span class="">link</span></dt>
+       <dd class="rounded-all">
+        <p>Member profile link, provides a link to the members chapter profile</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the Group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Membership status in this Group.
+Value may be one of
+active, blocked, pending, pending_payment or none</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>The last time this member edited their Group profile, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+       <dd class="rounded-all">
+        <p>The last time this member visited the Group, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Unique numeric identifier for the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_pro_admin"><span class="">is_pro_admin</span></dt>
+    <dd class="rounded-all">
+    <p>Returns true if the member is an active admin of an active meetup pro network</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="joined"><span class="">joined</span></dt>
+    <dd class="rounded-all">
+    <p>Time member joined, represented as milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="last_event"><span class="">last_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the last RSVP'd Meetup this member attended within the last two weeks,
+where available. Returned when the "fields"
+request parameter value contains "last_event"
+only for the profile of the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+       <dd class="rounded-all">
+        <p>Is event date matches the series pattern</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+       <dd class="rounded-all">
+        <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Ticketing fee information for events that support payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+            <dd class="rounded-all"><p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p></dd>
+            
+            <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+            <dd class="rounded-all"><p>Amount of the fee</p></dd>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Fee description, typically "per-person"</p></dd>
+            
+            <dt class="align-right bold" title="label"><span class="">label</span></dt>
+            <dd class="rounded-all"><p>Label for fee, typically "Price"</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>Boolean flag indicating if this fee is required to RSVP</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>Group hosting the event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate group latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate group longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="region"><span class="">region</span></dt>
+            <dd class="rounded-all"><p>Language and region of the group</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of the group</p></dd>
+            
+            <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+            <dd class="rounded-all"><p>Timezone of group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric urlname identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>A unique alphanumeric identifier for event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+       <dd class="rounded-all">
+        <p>Is event happening online</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+       <dd class="rounded-all">
+        <p>The local date of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+       <dd class="rounded-all">
+        <p>The local time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+       <dd class="rounded-all">
+        <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+       <dd class="rounded-all">
+        <p>Information about photo uploads for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="event"><span class="">event</span></dt>
+            <dd class="rounded-all"><p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for photo album</p></dd>
+            
+            <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+            <dd class="rounded-all"><p>Number of photos uploaded</p></dd>
+            
+            <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+            <dd class="rounded-all"><p>A small collection of photos uploaded for this event</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Album title</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+       <dd class="rounded-all">
+        <p>The number of "yes" RSVPS an event has capacity for</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection RSVPs for members attending this event, returned when the "fields" request parameter value includes "rsvp_sample"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>Creation time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p></dd>
+            
+            <dt class="align-right bold" title="member"><span class="">member</span></dt>
+            <dd class="rounded-all"><p>Member who RSVP'd</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>Last modified time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="series"><span class="">series</span></dt>
+       <dd class="rounded-all">
+        <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Human displayable description of how often events in this series occur</p></dd>
+            
+            <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series ends/ended, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the series</p></dd>
+            
+            <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a monthly recurring series of events</p></dd>
+            
+            <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series begins/began, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the template event of the series</p></dd>
+            
+            <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a weekly recurring series of events</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+       <dd class="rounded-all">
+        <p>Contains a list of organizer-defined survey questions intended to be asked of RSVPing members.
+Returned when the "fields" request parameter
+contains "survey_questions"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric question identifier</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time for the event in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+       <dd class="rounded-all">
+        <p>The event venue, present only if selected and not hidden by an organizer</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+            <dd class="rounded-all"><p>Line 1 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+            <dd class="rounded-all"><p>Line 2 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+            <dd class="rounded-all"><p>Line 3 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="city"><span class="">city</span></dt>
+            <dd class="rounded-all"><p>City of venue</p></dd>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country code of venue</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric venue id</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+            <dd class="rounded-all"><p>The localized name of the venue's country</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Venue name</p></dd>
+            
+            <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+            <dd class="rounded-all"><p>Phone number of venue</p></dd>
+            
+            <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+            <dd class="rounded-all"><p>true if the editor of the event altered the original venues pin location, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of venue where available</p></dd>
+            
+            <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+            <dd class="rounded-all"><p>ZIP code if, venue is in US or Canada</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of members on the waitlist, if one exists</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs including guests</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Geographic latitude associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of country associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Geographic longitude associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="memberships"><span class="">memberships</span></dt>
+    <dd class="rounded-all">
+    <p>Group memberships affiliated with this member.
+Returned only when fields request parameter value includes "memberships".
+This list may be omitted if the member has opted to hide their groups from others.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="member"><span class="">member</span></dt>
+       <dd class="rounded-all">
+        <p>Memberships where member holds a basic membership</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>The time this member joined the Group, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="group"><span class="">group</span></dt>
+            <dd class="rounded-all"><p>The group associated with this membership</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the Group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Membership status in this Group.
+Value may be one of
+active, blocked, pending, pending_payment or none</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>The last time this member edited their Group profile, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+            <dd class="rounded-all"><p>The last time this member visited the Group, represented as milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="organizer"><span class="">organizer</span></dt>
+       <dd class="rounded-all">
+        <p>Memberships where member is on the group's lead team</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>The time this member joined the Group, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="group"><span class="">group</span></dt>
+            <dd class="rounded-all"><p>The group associated with this membership</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the Group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Membership status in this Group.
+Value may be one of
+active, blocked, pending, pending_payment or none</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>The last time this member edited their Group profile, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+            <dd class="rounded-all"><p>The last time this member visited the Group, represented as milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="messaging_pref"><span class="">messaging_pref</span></dt>
+    <dd class="rounded-all">
+    <p>The member's preference for being contacted from other members on the platform.
+Returned only when the fields request parameter value includes "messaging_pref".
+May be one of the following: "all_members", "groups_only", or "orgs_only"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Display name for the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="next_event"><span class="">next_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing either the current ongoing or next RSVP'd Meetup, where available.
+Returned when the "fields"
+request parameter value contains "next_event"
+only for the profile of the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+       <dd class="rounded-all">
+        <p>Is event date matches the series pattern</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+       <dd class="rounded-all">
+        <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Ticketing fee information for events that support payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+            <dd class="rounded-all"><p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p></dd>
+            
+            <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+            <dd class="rounded-all"><p>Amount of the fee</p></dd>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Fee description, typically "per-person"</p></dd>
+            
+            <dt class="align-right bold" title="label"><span class="">label</span></dt>
+            <dd class="rounded-all"><p>Label for fee, typically "Price"</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>Boolean flag indicating if this fee is required to RSVP</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>Group hosting the event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate group latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate group longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="region"><span class="">region</span></dt>
+            <dd class="rounded-all"><p>Language and region of the group</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of the group</p></dd>
+            
+            <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+            <dd class="rounded-all"><p>Timezone of group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric urlname identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>A unique alphanumeric identifier for event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+       <dd class="rounded-all">
+        <p>Is event happening online</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+       <dd class="rounded-all">
+        <p>The local date of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+       <dd class="rounded-all">
+        <p>The local time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+       <dd class="rounded-all">
+        <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+       <dd class="rounded-all">
+        <p>Information about photo uploads for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="event"><span class="">event</span></dt>
+            <dd class="rounded-all"><p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for photo album</p></dd>
+            
+            <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+            <dd class="rounded-all"><p>Number of photos uploaded</p></dd>
+            
+            <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+            <dd class="rounded-all"><p>A small collection of photos uploaded for this event</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Album title</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+       <dd class="rounded-all">
+        <p>The number of "yes" RSVPS an event has capacity for</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection RSVPs for members attending this event, returned when the "fields" request parameter value includes "rsvp_sample"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>Creation time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p></dd>
+            
+            <dt class="align-right bold" title="member"><span class="">member</span></dt>
+            <dd class="rounded-all"><p>Member who RSVP'd</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>Last modified time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="series"><span class="">series</span></dt>
+       <dd class="rounded-all">
+        <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Human displayable description of how often events in this series occur</p></dd>
+            
+            <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series ends/ended, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the series</p></dd>
+            
+            <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a monthly recurring series of events</p></dd>
+            
+            <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series begins/began, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the template event of the series</p></dd>
+            
+            <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a weekly recurring series of events</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+       <dd class="rounded-all">
+        <p>Contains a list of organizer-defined survey questions intended to be asked of RSVPing members.
+Returned when the "fields" request parameter
+contains "survey_questions"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric question identifier</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time for the event in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+       <dd class="rounded-all">
+        <p>The event venue, present only if selected and not hidden by an organizer</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+            <dd class="rounded-all"><p>Line 1 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+            <dd class="rounded-all"><p>Line 2 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+            <dd class="rounded-all"><p>Line 3 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="city"><span class="">city</span></dt>
+            <dd class="rounded-all"><p>City of venue</p></dd>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country code of venue</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric venue id</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+            <dd class="rounded-all"><p>The localized name of the venue's country</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Venue name</p></dd>
+            
+            <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+            <dd class="rounded-all"><p>Phone number of venue</p></dd>
+            
+            <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+            <dd class="rounded-all"><p>true if the editor of the event altered the original venues pin location, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of venue where available</p></dd>
+            
+            <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+            <dd class="rounded-all"><p>ZIP code if, venue is in US or Canada</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of members on the waitlist, if one exists</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs including guests</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="other_services"><span class="">other_services</span></dt>
+    <dd class="rounded-all">
+    <p>An object whose key's are the names of associated external
+networks and values are identities within those networks.
+The keys may be one of facebook, flickr, linkedin, tumblr or twitter.
+Returned only when "fields" request parameter value
+includes "other_services"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="identifier"><span class="">identifier</span></dt>
+       <dd class="rounded-all">
+        <p>A unique string identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="url"><span class="">url</span></dt>
+       <dd class="rounded-all">
+        <p>A url for this identity. May be the same as identifier in some cases</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+    <dd class="rounded-all">
+    <p>Member photo. May be absent if member has not chosen one.
+In group contexts, the Member's Group profile photo will be returned.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="privacy"><span class="">privacy</span></dt>
+    <dd class="rounded-all">
+    <p>Member's privacy preferences
+Returned only when the "fields" request parameter value includes "privacy"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="facebook"><span class="">facebook</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' of 'visible'.
+If absent, the member has not connected their Facebook account to Meetup</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible'</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Represents the authenticated member's relation to member.
+Returned when "fields" request parameter value includes "self" and
+the target member is not the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions available for the authenticated member to perform.
+Currently only "message" is supported</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="blocks"><span class="">blocks</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indication of whether or not the authenticated member blocks this member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="common"><span class="">common</span></dt>
+       <dd class="rounded-all">
+        <p>Information the authenticated member has in common with this member</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+            <dd class="rounded-all"><p>List of common groups</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="friends"><span class="">friends</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indication of whether or not the authenticated member is a friend of the member</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State associated with Member's location, where available</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="stats"><span class="">stats</span></dt>
+    <dd class="rounded-all">
+    <p>High level numeric member statistics
+Returned only when fields request parameter value includes 'stats'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+       <dd class="rounded-all">
+        <p>Number of Meetup Group memberships.
+May be 0 if member chose to hide their groups from others</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvps"><span class="">rsvps</span></dt>
+       <dd class="rounded-all">
+        <p>Number of RSVPs.
+May be 0 if member chose to hide their groups from others</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>Number of Meetup topics member is interested in.
+May be 0 if member chose to hide their topics from others</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>a string with one of the following values: {'active', 'prereg', 'unknown'}</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+    <dd class="rounded-all">
+    <p>List of Meetup topics Member has interest in.
+Returned only when fields request parameter value includes "topics".
+This list may be omitted when member has opted to hide the topics from others.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+       <dd class="rounded-all">
+        <p>Language topic originates from</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+       <dd class="rounded-all">
+        <p>The unique keyword used to identify this topic</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+  
+  </dl>
+  
+  <h4 id="createerrors" class="rounded-all">Errors</h4>
+  <dl>
+  
+    <dt class="align-right bold"><span class="">intro_error</span></dt>
+    <dd><p>Intro was required but absent or appeared to contain spam</p></dd>
+  
+    <dt class="align-right bold"><span class="">join_closed_error</span></dt>
+    <dd><p>The organizer of this group has turned off new member joins</p></dd>
+  
+    <dt class="align-right bold"><span class="">join_error</span></dt>
+    <dd><p>A catch all join error for any additional error states</p></dd>
+  
+    <dt class="align-right bold"><span class="">member_banned</span></dt>
+    <dd><p>You have been banned from this group</p></dd>
+  
+    <dt class="align-right bold"><span class="">member_email</span></dt>
+    <dd><p>The email associated with this account is invalid</p></dd>
+  
+    <dt class="align-right bold"><span class="">member_removed</span></dt>
+    <dd><p>You have been removed from this group</p></dd>
+  
+    <dt class="align-right bold"><span class="">member_unapproved</span></dt>
+    <dd><p>Your membership approval was declined</p></dd>
+  
+    <dt class="align-right bold"><span class="">membership_error</span></dt>
+    <dd><p>Authenticated member was already an active member of this group</p></dd>
+  
+    <dt class="align-right bold"><span class="">missing_dues_error</span></dt>
+    <dd><p>Member did not meet group membership dues requirements</p></dd>
+  
+    <dt class="align-right bold"><span class="">pending_payment</span></dt>
+    <dd><p>Your current membership is pending a payment</p></dd>
+  
+    <dt class="align-right bold"><span class="">photo_error</span></dt>
+    <dd><p>Photo was required but absent</p></dd>
+  
+    <dt class="align-right bold"><span class="">unjoinable_group</span></dt>
+    <dd><p>This group is no longer joinable</p></dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_members_:member_id.html
+++ b/test/data/_:urlname_members_:member_id.html
@@ -1,0 +1,2696 @@
+
+        
+
+<div id="get">
+  <h2>Get Group Member Profile</h2>
+  <div id="geturi" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/members/:member_id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Gets Group Profiles.
+For Member Profiles, see <a href="/meetup_api/docs/members/:member_id">this endpoint</a></p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/members/:member_id">Try it in the console</a></p>
+  <h3 id="getparams" class="rounded-all">Request Parameters</h3>
+  <div class="getparam-notes"><p>A valid path parameter for :urlname and :member_id is required. A value of "self"
+may be used in place of a numeric identifier to represent the authenticated
+Member's id</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited string of optional response field names.
+This may include birthday, gender, groups, privacy, self and topics</p></dd>
+  
+  </dl>
+  
+  <h3 id="getresponse" class="rounded-all">Response</h3>
+  <p>Returns a single Member Profile object with embedded group Profile information.
+If the group's content is restricted to groups members and the authenticated member
+is not a member of the group, a 403 Forbidden error response will be returned.</p>
+  <dl>
+   
+    <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+    <dd class="rounded-all">
+    <p>Member bio. When profile does not belong to the authenticated member, this may be omitted if member opted to hide their bio from others</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="birthday"><span class="">birthday</span></dt>
+    <dd class="rounded-all">
+    <p>Returned only when the fields request parameter value includes 'birthday'
+and only for the authenticated member when defined</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="day"><span class="">day</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric day member was born. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="month"><span class="">month</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric month member was born. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="year"><span class="">year</span></dt>
+       <dd class="rounded-all">
+        <p>Year member was born</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country code associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="email"><span class="">email</span></dt>
+    <dd class="rounded-all">
+    <p>Member email address. Provided only if a profile belongs to the authenticated member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="gender"><span class="">gender</span></dt>
+    <dd class="rounded-all">
+    <p>Returned only when the fields request parameter value includes "gender"
+and only for the authenticated member.
+Value may be one of "female", "male", "none", or "other".
+This field may be absent where gender is not defined</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_profile"><span class="">group_profile</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup Group profile information.
+This field is only returned when profile is requested in group contexts</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+       <dd class="rounded-all">
+        <p>Array of answers to Group Profile questions</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="answer"><span class="">answer</span></dt>
+            <dd class="rounded-all"><p>Answer text</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+            <dt class="align-right bold" title="question_id"><span class="">question_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric question identifier</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>The time this member joined the Group, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>The group associated with this membership</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+            <dd class="rounded-all"><p>Group photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric group ID</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Who can join this group and how. One of "approval", "closed", or "open"</p></dd>
+            
+            <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+            <dd class="rounded-all"><p>Group primary photo</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+            <dd class="rounded-all"><p>Color combination used generate group duotone</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Status of the group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Urlname used to identify the group on meetup.com</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="intro"><span class="">intro</span></dt>
+       <dd class="rounded-all">
+        <p>Member intro, may be omitted if member opted to hide their intro from other members</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="link"><span class="">link</span></dt>
+       <dd class="rounded-all">
+        <p>Member profile link, provides a link to the members chapter profile</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the Group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Membership status in this Group.
+Value may be one of
+active, blocked, pending, pending_payment or none</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>The last time this member edited their Group profile, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+       <dd class="rounded-all">
+        <p>The last time this member visited the Group, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Unique numeric identifier for the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_pro_admin"><span class="">is_pro_admin</span></dt>
+    <dd class="rounded-all">
+    <p>Returns true if the member is an active admin of an active meetup pro network</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="joined"><span class="">joined</span></dt>
+    <dd class="rounded-all">
+    <p>Time member joined, represented as milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="last_event"><span class="">last_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the last RSVP'd Meetup this member attended within the last two weeks,
+where available. Returned when the "fields"
+request parameter value contains "last_event"
+only for the profile of the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+       <dd class="rounded-all">
+        <p>Is event date matches the series pattern</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+       <dd class="rounded-all">
+        <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Ticketing fee information for events that support payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+            <dd class="rounded-all"><p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p></dd>
+            
+            <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+            <dd class="rounded-all"><p>Amount of the fee</p></dd>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Fee description, typically "per-person"</p></dd>
+            
+            <dt class="align-right bold" title="label"><span class="">label</span></dt>
+            <dd class="rounded-all"><p>Label for fee, typically "Price"</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>Boolean flag indicating if this fee is required to RSVP</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>Group hosting the event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate group latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate group longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="region"><span class="">region</span></dt>
+            <dd class="rounded-all"><p>Language and region of the group</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of the group</p></dd>
+            
+            <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+            <dd class="rounded-all"><p>Timezone of group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric urlname identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>A unique alphanumeric identifier for event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+       <dd class="rounded-all">
+        <p>Is event happening online</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+       <dd class="rounded-all">
+        <p>The local date of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+       <dd class="rounded-all">
+        <p>The local time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+       <dd class="rounded-all">
+        <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+       <dd class="rounded-all">
+        <p>Information about photo uploads for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="event"><span class="">event</span></dt>
+            <dd class="rounded-all"><p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for photo album</p></dd>
+            
+            <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+            <dd class="rounded-all"><p>Number of photos uploaded</p></dd>
+            
+            <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+            <dd class="rounded-all"><p>A small collection of photos uploaded for this event</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Album title</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+       <dd class="rounded-all">
+        <p>The number of "yes" RSVPS an event has capacity for</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection RSVPs for members attending this event, returned when the "fields" request parameter value includes "rsvp_sample"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>Creation time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p></dd>
+            
+            <dt class="align-right bold" title="member"><span class="">member</span></dt>
+            <dd class="rounded-all"><p>Member who RSVP'd</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>Last modified time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="series"><span class="">series</span></dt>
+       <dd class="rounded-all">
+        <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Human displayable description of how often events in this series occur</p></dd>
+            
+            <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series ends/ended, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the series</p></dd>
+            
+            <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a monthly recurring series of events</p></dd>
+            
+            <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series begins/began, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the template event of the series</p></dd>
+            
+            <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a weekly recurring series of events</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+       <dd class="rounded-all">
+        <p>Contains a list of organizer-defined survey questions intended to be asked of RSVPing members.
+Returned when the "fields" request parameter
+contains "survey_questions"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric question identifier</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time for the event in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+       <dd class="rounded-all">
+        <p>The event venue, present only if selected and not hidden by an organizer</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+            <dd class="rounded-all"><p>Line 1 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+            <dd class="rounded-all"><p>Line 2 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+            <dd class="rounded-all"><p>Line 3 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="city"><span class="">city</span></dt>
+            <dd class="rounded-all"><p>City of venue</p></dd>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country code of venue</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric venue id</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+            <dd class="rounded-all"><p>The localized name of the venue's country</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Venue name</p></dd>
+            
+            <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+            <dd class="rounded-all"><p>Phone number of venue</p></dd>
+            
+            <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+            <dd class="rounded-all"><p>true if the editor of the event altered the original venues pin location, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of venue where available</p></dd>
+            
+            <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+            <dd class="rounded-all"><p>ZIP code if, venue is in US or Canada</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of members on the waitlist, if one exists</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs including guests</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Geographic latitude associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of country associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Geographic longitude associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="memberships"><span class="">memberships</span></dt>
+    <dd class="rounded-all">
+    <p>Group memberships affiliated with this member.
+Returned only when fields request parameter value includes "memberships".
+This list may be omitted if the member has opted to hide their groups from others.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="member"><span class="">member</span></dt>
+       <dd class="rounded-all">
+        <p>Memberships where member holds a basic membership</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>The time this member joined the Group, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="group"><span class="">group</span></dt>
+            <dd class="rounded-all"><p>The group associated with this membership</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the Group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Membership status in this Group.
+Value may be one of
+active, blocked, pending, pending_payment or none</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>The last time this member edited their Group profile, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+            <dd class="rounded-all"><p>The last time this member visited the Group, represented as milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="organizer"><span class="">organizer</span></dt>
+       <dd class="rounded-all">
+        <p>Memberships where member is on the group's lead team</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>The time this member joined the Group, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="group"><span class="">group</span></dt>
+            <dd class="rounded-all"><p>The group associated with this membership</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the Group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Membership status in this Group.
+Value may be one of
+active, blocked, pending, pending_payment or none</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>The last time this member edited their Group profile, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+            <dd class="rounded-all"><p>The last time this member visited the Group, represented as milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="messaging_pref"><span class="">messaging_pref</span></dt>
+    <dd class="rounded-all">
+    <p>The member's preference for being contacted from other members on the platform.
+Returned only when the fields request parameter value includes "messaging_pref".
+May be one of the following: "all_members", "groups_only", or "orgs_only"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Display name for the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="next_event"><span class="">next_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing either the current ongoing or next RSVP'd Meetup, where available.
+Returned when the "fields"
+request parameter value contains "next_event"
+only for the profile of the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+       <dd class="rounded-all">
+        <p>Is event date matches the series pattern</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+       <dd class="rounded-all">
+        <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Ticketing fee information for events that support payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+            <dd class="rounded-all"><p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p></dd>
+            
+            <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+            <dd class="rounded-all"><p>Amount of the fee</p></dd>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Fee description, typically "per-person"</p></dd>
+            
+            <dt class="align-right bold" title="label"><span class="">label</span></dt>
+            <dd class="rounded-all"><p>Label for fee, typically "Price"</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>Boolean flag indicating if this fee is required to RSVP</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>Group hosting the event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate group latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate group longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="region"><span class="">region</span></dt>
+            <dd class="rounded-all"><p>Language and region of the group</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of the group</p></dd>
+            
+            <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+            <dd class="rounded-all"><p>Timezone of group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric urlname identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>A unique alphanumeric identifier for event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+       <dd class="rounded-all">
+        <p>Is event happening online</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+       <dd class="rounded-all">
+        <p>The local date of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+       <dd class="rounded-all">
+        <p>The local time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+       <dd class="rounded-all">
+        <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+       <dd class="rounded-all">
+        <p>Information about photo uploads for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="event"><span class="">event</span></dt>
+            <dd class="rounded-all"><p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for photo album</p></dd>
+            
+            <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+            <dd class="rounded-all"><p>Number of photos uploaded</p></dd>
+            
+            <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+            <dd class="rounded-all"><p>A small collection of photos uploaded for this event</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Album title</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+       <dd class="rounded-all">
+        <p>The number of "yes" RSVPS an event has capacity for</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection RSVPs for members attending this event, returned when the "fields" request parameter value includes "rsvp_sample"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>Creation time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p></dd>
+            
+            <dt class="align-right bold" title="member"><span class="">member</span></dt>
+            <dd class="rounded-all"><p>Member who RSVP'd</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>Last modified time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="series"><span class="">series</span></dt>
+       <dd class="rounded-all">
+        <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Human displayable description of how often events in this series occur</p></dd>
+            
+            <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series ends/ended, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the series</p></dd>
+            
+            <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a monthly recurring series of events</p></dd>
+            
+            <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series begins/began, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the template event of the series</p></dd>
+            
+            <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a weekly recurring series of events</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+       <dd class="rounded-all">
+        <p>Contains a list of organizer-defined survey questions intended to be asked of RSVPing members.
+Returned when the "fields" request parameter
+contains "survey_questions"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric question identifier</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time for the event in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+       <dd class="rounded-all">
+        <p>The event venue, present only if selected and not hidden by an organizer</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+            <dd class="rounded-all"><p>Line 1 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+            <dd class="rounded-all"><p>Line 2 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+            <dd class="rounded-all"><p>Line 3 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="city"><span class="">city</span></dt>
+            <dd class="rounded-all"><p>City of venue</p></dd>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country code of venue</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric venue id</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+            <dd class="rounded-all"><p>The localized name of the venue's country</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Venue name</p></dd>
+            
+            <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+            <dd class="rounded-all"><p>Phone number of venue</p></dd>
+            
+            <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+            <dd class="rounded-all"><p>true if the editor of the event altered the original venues pin location, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of venue where available</p></dd>
+            
+            <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+            <dd class="rounded-all"><p>ZIP code if, venue is in US or Canada</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of members on the waitlist, if one exists</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs including guests</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="other_services"><span class="">other_services</span></dt>
+    <dd class="rounded-all">
+    <p>An object whose key's are the names of associated external
+networks and values are identities within those networks.
+The keys may be one of facebook, flickr, linkedin, tumblr or twitter.
+Returned only when "fields" request parameter value
+includes "other_services"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="identifier"><span class="">identifier</span></dt>
+       <dd class="rounded-all">
+        <p>A unique string identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="url"><span class="">url</span></dt>
+       <dd class="rounded-all">
+        <p>A url for this identity. May be the same as identifier in some cases</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+    <dd class="rounded-all">
+    <p>Member photo. May be absent if member has not chosen one.
+In group contexts, the Member's Group profile photo will be returned.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="privacy"><span class="">privacy</span></dt>
+    <dd class="rounded-all">
+    <p>Member's privacy preferences
+Returned only when the "fields" request parameter value includes "privacy"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="facebook"><span class="">facebook</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' of 'visible'.
+If absent, the member has not connected their Facebook account to Meetup</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible'</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Represents the authenticated member's relation to member.
+Returned when "fields" request parameter value includes "self" and
+the target member is not the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions available for the authenticated member to perform.
+Currently only "message" is supported</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="blocks"><span class="">blocks</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indication of whether or not the authenticated member blocks this member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="common"><span class="">common</span></dt>
+       <dd class="rounded-all">
+        <p>Information the authenticated member has in common with this member</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+            <dd class="rounded-all"><p>List of common groups</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="friends"><span class="">friends</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indication of whether or not the authenticated member is a friend of the member</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State associated with Member's location, where available</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="stats"><span class="">stats</span></dt>
+    <dd class="rounded-all">
+    <p>High level numeric member statistics
+Returned only when fields request parameter value includes 'stats'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+       <dd class="rounded-all">
+        <p>Number of Meetup Group memberships.
+May be 0 if member chose to hide their groups from others</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvps"><span class="">rsvps</span></dt>
+       <dd class="rounded-all">
+        <p>Number of RSVPs.
+May be 0 if member chose to hide their groups from others</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>Number of Meetup topics member is interested in.
+May be 0 if member chose to hide their topics from others</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>a string with one of the following values: {'active', 'prereg', 'unknown'}</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+    <dd class="rounded-all">
+    <p>List of Meetup topics Member has interest in.
+Returned only when fields request parameter value includes "topics".
+This list may be omitted when member has opted to hide the topics from others.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+       <dd class="rounded-all">
+        <p>Language topic originates from</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+       <dd class="rounded-all">
+        <p>The unique keyword used to identify this topic</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+  
+  </dl>
+  
+  
+  <h3 id="getexamples" class="rounded-all">Examples</h3>
+  <p>Fetch your own group profile</p>
+<pre><code>curl -H "Authorization: bearer {ACCESS_TOKEN}" \
+  "https://meetup.com/meetup-api-testing/members/self"
+</code></pre>
+  
+</div>
+
+<div id="edit">
+  <h2>Edit Group Member Profile</h2>
+  <div id="edituri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">PATCH</strong> /:urlname/members/:member_id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">profile_edit</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Edits Group Profiles.
+To fetch Group Member Profiles,
+see <a href="/meetup_api/docs/:urlname/members/:member_id#get">this endpoint</a></p>
+  </div>
+  
+  <h3 id="editparams" class="rounded-all">Request Parameters</h3>
+  <div class="editparam-notes"><p>A valid path parameter for :urlname and :member_id is required. A value of "self"
+may be used in place of a numeric identifier to represent the authenticated
+Member's id.</p>
+<p>OAuth authenticated applications should
+request the <a href="/meetup_api/auth/#profile_edit_scope">profile_edit</a>
+permission scope</p>
+<p>Only organizers of the Meetup group may edit the member's <strong>title</strong> and <strong>role</strong> within the group.</p>
+<p>All other fields are restricted to the owner of the group profile.</p>
+<p>Some Meetup group organizers may define a set of profile questions
+they'd like their members to answer. You can obtain that question
+list using the <a href="/meetup_api/docs/:urlname/#get">Get Group</a> by sending
+ a "fields" request parameter containing
+"join_info"</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="add_role"><span class="">add_role</span></dt>
+    <dd class="rounded-all"><p>Allows those with permission to assign one of the following roles:
+"assistant_organizer", "coorganizer", or "event_organizer"</p></dd>
+  
+    <dt class="align-right bold" title="answer_{qid}"><span class="">answer_{qid}</span></dt>
+    <dd class="rounded-all"><p>Answers to questions from group's API join_info question fields.</p>
+<p>The name of these parameters must contain a suffix of _ + the numeric
+question id from the Meetup group's join info question list</p>
+<p>Answers may not be longer than 1000
+characters in length</p></dd>
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited string of optional response field names.
+This may include birthday, gender, groups, privacy, self and topics</p></dd>
+  
+    <dt class="align-right bold" title="intro"><span class="">intro</span></dt>
+    <dd class="rounded-all"><p>Provides a Member an opportunity to tell the group about themselves,
+in at most 255 characters</p></dd>
+  
+    <dt class="align-right bold" title="photo_id"><span class="">photo_id</span></dt>
+    <dd class="rounded-all"><p>Numeric id of the photo to use for this profile. Send a value of 0 to unset the current photo</p></dd>
+  
+    <dt class="align-right bold" title="remove_role"><span class="">remove_role</span></dt>
+    <dd class="rounded-all"><p>Allows those with permission to remove one of the following roles:
+"assistant_organizer", "coorganizer", or "event_organizer"</p></dd>
+  
+    <dt class="align-right bold" title="title"><span class="">title</span></dt>
+    <dd class="rounded-all"><p>An organizer-defined title,
+in at most 255 characters</p></dd>
+  
+  </dl>
+  
+  <h3 id="editresponse" class="rounded-all">Response</h3>
+  <p>Returns a single Member Profile object with embedded group profile information.
+If a request is made that violates one of the field restrictions mentioned above,
+a 403 Forbidden error response will be returned.</p>
+  <dl>
+   
+    <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+    <dd class="rounded-all">
+    <p>Member bio. When profile does not belong to the authenticated member, this may be omitted if member opted to hide their bio from others</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="birthday"><span class="">birthday</span></dt>
+    <dd class="rounded-all">
+    <p>Returned only when the fields request parameter value includes 'birthday'
+and only for the authenticated member when defined</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="day"><span class="">day</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric day member was born. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="month"><span class="">month</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric month member was born. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="year"><span class="">year</span></dt>
+       <dd class="rounded-all">
+        <p>Year member was born</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country code associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="email"><span class="">email</span></dt>
+    <dd class="rounded-all">
+    <p>Member email address. Provided only if a profile belongs to the authenticated member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="gender"><span class="">gender</span></dt>
+    <dd class="rounded-all">
+    <p>Returned only when the fields request parameter value includes "gender"
+and only for the authenticated member.
+Value may be one of "female", "male", "none", or "other".
+This field may be absent where gender is not defined</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_profile"><span class="">group_profile</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup Group profile information.
+This field is only returned when profile is requested in group contexts</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+       <dd class="rounded-all">
+        <p>Array of answers to Group Profile questions</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="answer"><span class="">answer</span></dt>
+            <dd class="rounded-all"><p>Answer text</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+            <dt class="align-right bold" title="question_id"><span class="">question_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric question identifier</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>The time this member joined the Group, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>The group associated with this membership</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+            <dd class="rounded-all"><p>Group photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric group ID</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Who can join this group and how. One of "approval", "closed", or "open"</p></dd>
+            
+            <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+            <dd class="rounded-all"><p>Group primary photo</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+            <dd class="rounded-all"><p>Color combination used generate group duotone</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Status of the group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Urlname used to identify the group on meetup.com</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="intro"><span class="">intro</span></dt>
+       <dd class="rounded-all">
+        <p>Member intro, may be omitted if member opted to hide their intro from other members</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="link"><span class="">link</span></dt>
+       <dd class="rounded-all">
+        <p>Member profile link, provides a link to the members chapter profile</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the Group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Membership status in this Group.
+Value may be one of
+active, blocked, pending, pending_payment or none</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>The last time this member edited their Group profile, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+       <dd class="rounded-all">
+        <p>The last time this member visited the Group, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Unique numeric identifier for the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_pro_admin"><span class="">is_pro_admin</span></dt>
+    <dd class="rounded-all">
+    <p>Returns true if the member is an active admin of an active meetup pro network</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="joined"><span class="">joined</span></dt>
+    <dd class="rounded-all">
+    <p>Time member joined, represented as milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="last_event"><span class="">last_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the last RSVP'd Meetup this member attended within the last two weeks,
+where available. Returned when the "fields"
+request parameter value contains "last_event"
+only for the profile of the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+       <dd class="rounded-all">
+        <p>Is event date matches the series pattern</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+       <dd class="rounded-all">
+        <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Ticketing fee information for events that support payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+            <dd class="rounded-all"><p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p></dd>
+            
+            <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+            <dd class="rounded-all"><p>Amount of the fee</p></dd>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Fee description, typically "per-person"</p></dd>
+            
+            <dt class="align-right bold" title="label"><span class="">label</span></dt>
+            <dd class="rounded-all"><p>Label for fee, typically "Price"</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>Boolean flag indicating if this fee is required to RSVP</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>Group hosting the event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate group latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate group longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="region"><span class="">region</span></dt>
+            <dd class="rounded-all"><p>Language and region of the group</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of the group</p></dd>
+            
+            <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+            <dd class="rounded-all"><p>Timezone of group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric urlname identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>A unique alphanumeric identifier for event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+       <dd class="rounded-all">
+        <p>Is event happening online</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+       <dd class="rounded-all">
+        <p>The local date of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+       <dd class="rounded-all">
+        <p>The local time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+       <dd class="rounded-all">
+        <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+       <dd class="rounded-all">
+        <p>Information about photo uploads for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="event"><span class="">event</span></dt>
+            <dd class="rounded-all"><p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for photo album</p></dd>
+            
+            <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+            <dd class="rounded-all"><p>Number of photos uploaded</p></dd>
+            
+            <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+            <dd class="rounded-all"><p>A small collection of photos uploaded for this event</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Album title</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+       <dd class="rounded-all">
+        <p>The number of "yes" RSVPS an event has capacity for</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection RSVPs for members attending this event, returned when the "fields" request parameter value includes "rsvp_sample"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>Creation time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p></dd>
+            
+            <dt class="align-right bold" title="member"><span class="">member</span></dt>
+            <dd class="rounded-all"><p>Member who RSVP'd</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>Last modified time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="series"><span class="">series</span></dt>
+       <dd class="rounded-all">
+        <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Human displayable description of how often events in this series occur</p></dd>
+            
+            <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series ends/ended, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the series</p></dd>
+            
+            <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a monthly recurring series of events</p></dd>
+            
+            <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series begins/began, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the template event of the series</p></dd>
+            
+            <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a weekly recurring series of events</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+       <dd class="rounded-all">
+        <p>Contains a list of organizer-defined survey questions intended to be asked of RSVPing members.
+Returned when the "fields" request parameter
+contains "survey_questions"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric question identifier</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time for the event in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+       <dd class="rounded-all">
+        <p>The event venue, present only if selected and not hidden by an organizer</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+            <dd class="rounded-all"><p>Line 1 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+            <dd class="rounded-all"><p>Line 2 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+            <dd class="rounded-all"><p>Line 3 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="city"><span class="">city</span></dt>
+            <dd class="rounded-all"><p>City of venue</p></dd>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country code of venue</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric venue id</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+            <dd class="rounded-all"><p>The localized name of the venue's country</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Venue name</p></dd>
+            
+            <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+            <dd class="rounded-all"><p>Phone number of venue</p></dd>
+            
+            <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+            <dd class="rounded-all"><p>true if the editor of the event altered the original venues pin location, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of venue where available</p></dd>
+            
+            <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+            <dd class="rounded-all"><p>ZIP code if, venue is in US or Canada</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of members on the waitlist, if one exists</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs including guests</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Geographic latitude associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of country associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Geographic longitude associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="memberships"><span class="">memberships</span></dt>
+    <dd class="rounded-all">
+    <p>Group memberships affiliated with this member.
+Returned only when fields request parameter value includes "memberships".
+This list may be omitted if the member has opted to hide their groups from others.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="member"><span class="">member</span></dt>
+       <dd class="rounded-all">
+        <p>Memberships where member holds a basic membership</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>The time this member joined the Group, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="group"><span class="">group</span></dt>
+            <dd class="rounded-all"><p>The group associated with this membership</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the Group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Membership status in this Group.
+Value may be one of
+active, blocked, pending, pending_payment or none</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>The last time this member edited their Group profile, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+            <dd class="rounded-all"><p>The last time this member visited the Group, represented as milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="organizer"><span class="">organizer</span></dt>
+       <dd class="rounded-all">
+        <p>Memberships where member is on the group's lead team</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>The time this member joined the Group, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="group"><span class="">group</span></dt>
+            <dd class="rounded-all"><p>The group associated with this membership</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the Group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Membership status in this Group.
+Value may be one of
+active, blocked, pending, pending_payment or none</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>The last time this member edited their Group profile, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+            <dd class="rounded-all"><p>The last time this member visited the Group, represented as milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="messaging_pref"><span class="">messaging_pref</span></dt>
+    <dd class="rounded-all">
+    <p>The member's preference for being contacted from other members on the platform.
+Returned only when the fields request parameter value includes "messaging_pref".
+May be one of the following: "all_members", "groups_only", or "orgs_only"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Display name for the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="next_event"><span class="">next_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing either the current ongoing or next RSVP'd Meetup, where available.
+Returned when the "fields"
+request parameter value contains "next_event"
+only for the profile of the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+       <dd class="rounded-all">
+        <p>Is event date matches the series pattern</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+       <dd class="rounded-all">
+        <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Ticketing fee information for events that support payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+            <dd class="rounded-all"><p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p></dd>
+            
+            <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+            <dd class="rounded-all"><p>Amount of the fee</p></dd>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Fee description, typically "per-person"</p></dd>
+            
+            <dt class="align-right bold" title="label"><span class="">label</span></dt>
+            <dd class="rounded-all"><p>Label for fee, typically "Price"</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>Boolean flag indicating if this fee is required to RSVP</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>Group hosting the event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate group latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate group longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="region"><span class="">region</span></dt>
+            <dd class="rounded-all"><p>Language and region of the group</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of the group</p></dd>
+            
+            <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+            <dd class="rounded-all"><p>Timezone of group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric urlname identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>A unique alphanumeric identifier for event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+       <dd class="rounded-all">
+        <p>Is event happening online</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+       <dd class="rounded-all">
+        <p>The local date of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+       <dd class="rounded-all">
+        <p>The local time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+       <dd class="rounded-all">
+        <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+       <dd class="rounded-all">
+        <p>Information about photo uploads for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="event"><span class="">event</span></dt>
+            <dd class="rounded-all"><p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for photo album</p></dd>
+            
+            <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+            <dd class="rounded-all"><p>Number of photos uploaded</p></dd>
+            
+            <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+            <dd class="rounded-all"><p>A small collection of photos uploaded for this event</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Album title</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+       <dd class="rounded-all">
+        <p>The number of "yes" RSVPS an event has capacity for</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection RSVPs for members attending this event, returned when the "fields" request parameter value includes "rsvp_sample"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>Creation time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p></dd>
+            
+            <dt class="align-right bold" title="member"><span class="">member</span></dt>
+            <dd class="rounded-all"><p>Member who RSVP'd</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>Last modified time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="series"><span class="">series</span></dt>
+       <dd class="rounded-all">
+        <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Human displayable description of how often events in this series occur</p></dd>
+            
+            <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series ends/ended, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the series</p></dd>
+            
+            <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a monthly recurring series of events</p></dd>
+            
+            <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series begins/began, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the template event of the series</p></dd>
+            
+            <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a weekly recurring series of events</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+       <dd class="rounded-all">
+        <p>Contains a list of organizer-defined survey questions intended to be asked of RSVPing members.
+Returned when the "fields" request parameter
+contains "survey_questions"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric question identifier</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time for the event in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+       <dd class="rounded-all">
+        <p>The event venue, present only if selected and not hidden by an organizer</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+            <dd class="rounded-all"><p>Line 1 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+            <dd class="rounded-all"><p>Line 2 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+            <dd class="rounded-all"><p>Line 3 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="city"><span class="">city</span></dt>
+            <dd class="rounded-all"><p>City of venue</p></dd>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country code of venue</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric venue id</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+            <dd class="rounded-all"><p>The localized name of the venue's country</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Venue name</p></dd>
+            
+            <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+            <dd class="rounded-all"><p>Phone number of venue</p></dd>
+            
+            <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+            <dd class="rounded-all"><p>true if the editor of the event altered the original venues pin location, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of venue where available</p></dd>
+            
+            <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+            <dd class="rounded-all"><p>ZIP code if, venue is in US or Canada</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of members on the waitlist, if one exists</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs including guests</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="other_services"><span class="">other_services</span></dt>
+    <dd class="rounded-all">
+    <p>An object whose key's are the names of associated external
+networks and values are identities within those networks.
+The keys may be one of facebook, flickr, linkedin, tumblr or twitter.
+Returned only when "fields" request parameter value
+includes "other_services"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="identifier"><span class="">identifier</span></dt>
+       <dd class="rounded-all">
+        <p>A unique string identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="url"><span class="">url</span></dt>
+       <dd class="rounded-all">
+        <p>A url for this identity. May be the same as identifier in some cases</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+    <dd class="rounded-all">
+    <p>Member photo. May be absent if member has not chosen one.
+In group contexts, the Member's Group profile photo will be returned.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="privacy"><span class="">privacy</span></dt>
+    <dd class="rounded-all">
+    <p>Member's privacy preferences
+Returned only when the "fields" request parameter value includes "privacy"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="facebook"><span class="">facebook</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' of 'visible'.
+If absent, the member has not connected their Facebook account to Meetup</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible'</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Represents the authenticated member's relation to member.
+Returned when "fields" request parameter value includes "self" and
+the target member is not the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions available for the authenticated member to perform.
+Currently only "message" is supported</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="blocks"><span class="">blocks</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indication of whether or not the authenticated member blocks this member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="common"><span class="">common</span></dt>
+       <dd class="rounded-all">
+        <p>Information the authenticated member has in common with this member</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+            <dd class="rounded-all"><p>List of common groups</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="friends"><span class="">friends</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indication of whether or not the authenticated member is a friend of the member</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State associated with Member's location, where available</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="stats"><span class="">stats</span></dt>
+    <dd class="rounded-all">
+    <p>High level numeric member statistics
+Returned only when fields request parameter value includes 'stats'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+       <dd class="rounded-all">
+        <p>Number of Meetup Group memberships.
+May be 0 if member chose to hide their groups from others</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvps"><span class="">rsvps</span></dt>
+       <dd class="rounded-all">
+        <p>Number of RSVPs.
+May be 0 if member chose to hide their groups from others</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>Number of Meetup topics member is interested in.
+May be 0 if member chose to hide their topics from others</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>a string with one of the following values: {'active', 'prereg', 'unknown'}</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+    <dd class="rounded-all">
+    <p>List of Meetup topics Member has interest in.
+Returned only when fields request parameter value includes "topics".
+This list may be omitted when member has opted to hide the topics from others.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+       <dd class="rounded-all">
+        <p>Language topic originates from</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+       <dd class="rounded-all">
+        <p>The unique keyword used to identify this topic</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+  
+  </dl>
+  
+  
+  <h3 id="editexamples" class="rounded-all">Examples</h3>
+  <p>Edit your own group profile</p>
+<pre><code>curl -X PATCH -H "Authorization: bearer {ACCESS_TOKEN}" \
+  "https://meetup.com/meetup-api-testing/members/self" \
+   -d "answer_222854=building community"
+</code></pre>
+  
+</div>
+
+<div id="delete">
+  <h2>Delete Group Member Profile (Leave Group)</h2>
+  <div id="deleteuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">DELETE</strong> /:urlname/members/:member_id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">profile_edit</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Deletes a member's group profiles.</p>
+  </div>
+  
+  <h3 id="deleteparams" class="rounded-all">Request Parameters</h3>
+  <div class="deleteparam-notes"><p>A valid path parameter for :urlname and :member_id is required. A value of "self"
+may be used in place of a numeric identifier to represent the authenticated
+Member's id.</p>
+<p>OAuth authenticated applications should
+request the <a href="/meetup_api/auth/#profile_edit_scope">profile_edit</a>
+permission scope</p>
+<p>Only the authenticated member is permitted to leave groups they do not organize. For groups they do organize,
+they must first step down on the groups homepage on www.meetup.com</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="exit_comment"><span class="">exit_comment</span></dt>
+    <dd class="rounded-all"><p>Optional message to the organizer when leaving</p></dd>
+  
+  </dl>
+  
+  <h3 id="deleteresponse" class="rounded-all">Response</h3>
+  <p>A successful request will result in a 204 NoContent response.</p>
+<p>Attempts to delete profiles that do not belong to the authenticated member will result in a 403 Forbidden response</p>
+<p>Attempts to delete profiles in groups the authenticated member is an organizer of will result in a 400 BadRequest response</p>
+  <dl>
+  
+  </dl>
+  
+  <h4 id="deleteerrors" class="rounded-all">Errors</h4>
+  <dl>
+  
+    <dt class="align-right bold"><span class="">organizer_error</span></dt>
+    <dd><p>Returned when an organizer attempts to delete their profile before stepping down</p></dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_photo_albums.html
+++ b/test/data/_:urlname_photo_albums.html
@@ -1,0 +1,408 @@
+
+        
+
+<div id="">
+  <h2>Photo Album List</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/photo_albums
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Gets a list a group photo albums in ascending order based on the time they were created</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/photo_albums">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>A valid path parameter value for
+<strong>:urlname</strong> is required</p>
+<p>This endpoint uses HTTP <a href="/meetup_api/docs/#v3_json">Link header based pagination</a>.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional response fields.
+Currently supported values are "self" and "short_link"</p></dd>
+  
+    <dt class="align-right bold" title="offset"><span class="">offset</span></dt>
+    <dd class="rounded-all"><p>Incrementing number used for pagination offsets</p></dd>
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>Number of albums to return per page of results</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>Returns a list of album objects</p>
+  <dl>
+   
+    <dt class="align-right bold" title="album_photo"><span class="">album_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Cover photo for this photo album</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo album was created, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="event"><span class="">event</span></dt>
+    <dd class="rounded-all">
+    <p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>Group associated with this photo album</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric group ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used generate group duotone</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Status of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Unique numeric identifier for photo album</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to photo album on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of photos uploaded</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection of photos uploaded for this event</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Contextual information related to the authenticated member.
+Returned when 'self' is present
+in the 'fields' request parameter</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the member may perform.</p>
+<p>Currently only "upload_photo" may be expected</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Shortened link to photo album on meetup.com.
+Returned when 'short_link' is present
+in the 'fields' request parameter</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="title"><span class="">title</span></dt>
+    <dd class="rounded-all">
+    <p>Album title</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo album was last updated in milliseconds since the epoch</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_photo_albums_:album_id.html
+++ b/test/data/_:urlname_photo_albums_:album_id.html
@@ -1,0 +1,401 @@
+
+        
+
+<div id="">
+  <h2>Photo Album</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/photo_albums/:album_id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Gets information about a specific photo album</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/photo_albums/:album_id">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>A valid path parameter value for
+<strong>:urlname</strong> and <strong>:album_id</strong> is required</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional response fields.
+Currently supported values are "self" and "short_link"</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>Returns a photo album object</p>
+  <dl>
+   
+    <dt class="align-right bold" title="album_photo"><span class="">album_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Cover photo for this photo album</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo album was created, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="event"><span class="">event</span></dt>
+    <dd class="rounded-all">
+    <p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>Group associated with this photo album</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric group ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used generate group duotone</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Status of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Unique numeric identifier for photo album</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to photo album on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of photos uploaded</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection of photos uploaded for this event</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Contextual information related to the authenticated member.
+Returned when 'self' is present
+in the 'fields' request parameter</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the member may perform.</p>
+<p>Currently only "upload_photo" may be expected</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Shortened link to photo album on meetup.com.
+Returned when 'short_link' is present
+in the 'fields' request parameter</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="title"><span class="">title</span></dt>
+    <dd class="rounded-all">
+    <p>Album title</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo album was last updated in milliseconds since the epoch</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_photo_albums_:album_id_photos.html
+++ b/test/data/_:urlname_photo_albums_:album_id_photos.html
@@ -1,0 +1,931 @@
+
+        
+
+<div id="list">
+  <h2>Album Photos</h2>
+  <div id="listuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/photo_albums/:album_id/photos
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Lists photos for a given photo album</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/photo_albums/:album_id/photos">Try it in the console</a></p>
+  <h3 id="listparams" class="rounded-all">Request Parameters</h3>
+  <div class="listparam-notes"><p>A valid path parameter for
+<strong>:urlname</strong> and <strong>:album_id</strong> is required</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="desc"><span class="">desc</span></dt>
+    <dd class="rounded-all"><p>Controls directional order or listing. Default false</p></dd>
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional response fields.
+Currently supported values are
+"comment_count", "self" and "short_link"</p></dd>
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>Number of items to return per-page of results. Defaults to 200</p></dd>
+  
+  </dl>
+  
+  <h3 id="listresponse" class="rounded-all">Response</h3>
+  <p>Returns a list of photo objects</p>
+  <dl>
+   
+    <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+    <dd class="rounded-all">
+    <p>A base url that can be use to construct a photo url from its components</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="caption"><span class="">caption</span></dt>
+    <dd class="rounded-all">
+    <p>Photo caption, if defined</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="comment_count"><span class="">comment_count</span></dt>
+    <dd class="rounded-all">
+    <p>The number of comments posted about this photo.
+Returned when 'comment_count' is present
+in the 'fields' request parameter.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo was uploaded, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>Group the photo is associated with." +
+          "|Returned when 'group' is present " +
+          "|in the 'fields' request parameter.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric group ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used generate group duotone</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Status of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for full sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric photo ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to photo on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>Member who uploaded the photo. If member has since left the group,
+this will return a member with an id of 0</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Intro of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+       <dd class="rounded-all">
+        <p>Member's context within the event. Only returned in the context of an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host"><span class="">host</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator for whether this member is a host for the event</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+    <dd class="rounded-all">
+    <p>Photo album the photo is associated with</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="event"><span class="">event</span></dt>
+       <dd class="rounded-all">
+        <p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric event ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of event</p></dd>
+            
+            <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of no RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="time"><span class="">time</span></dt>
+            <dd class="rounded-all"><p>UTC start time of the event, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+            <dd class="rounded-all"><p>The local offset from UTC time, in milliseconds</p></dd>
+            
+            <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+            <dd class="rounded-all"><p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of yes RSVPs</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for photo album</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of photos uploaded</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Album title</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for standard sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Context for the authenticated member.
+Returned when 'self' is present
+in the 'fields' request parameter and the authenticated
+is a member of the group the photo is associated with.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform on this photo
+or its containing album, potentially one or more of the following</p>
+<p>"comment" if member can comment on this photo</p>
+<p>"delete" if the member can delete the photo</p>
+<p>"edit" if the member can edit the photo details</p>
+<p>"upload_photo" if the member can upload new photos</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Shortened link to photo on meetup.com. Returned when 'short_link'
+is present in the 'fields' request parameter</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for thumbnail sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="type"><span class="">type</span></dt>
+    <dd class="rounded-all">
+    <p>Type of photo. One of "event" or "member"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo was last updated, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric utc offset based on the timezone of the group
+hosting the event this photo was posted in</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="upload">
+  <h2>Album Photo Upload</h2>
+  <div id="uploaduri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname/photo_albums/:album_id/photos
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Support for uploading new Album photos</p>
+  </div>
+  
+  <h3 id="uploadparams" class="rounded-all">Request Parameters</h3>
+  <div class="uploadparam-notes"><p>A valid path parameter value for
+<strong>:urlname</strong> and <strong>:album_id</strong>
+is required</p>
+<p>This method expects an HTTP POST containing a Content-Type of <code>multipart/form-data</code>.
+Only the <code>photo</code> parameter, which represents the photo being uploaded, is required.</p>
+<p>Uploaded photos are fed into a separate photo staging process and may not be
+immediately available for display. To receive responses for photos that are immediately
+displayable, send the <code>await</code> request parameter with a value of <code>true</code>.</p>
+<p>A maximum of 500 photos are allowed for a given album.</p>
+<p>Authentication credentials should be omitted from the request body and be sent via
+HTTP Authorization header or as query string parameters</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="await"><span class="">await</span></dt>
+    <dd class="rounded-all"><p>Optional boolean parameter that will defer a request's a response until confirmation that photo is immediately displayable is received.</p></dd>
+  
+    <dt class="align-right bold" title="caption"><span class="">caption</span></dt>
+    <dd class="rounded-all"><p>Caption for display. Max length 255</p></dd>
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional response fields.
+Currently supported values are "self" and "comment_count"</p></dd>
+  
+    <dt class="align-right bold" title="photo"><span class="param_required">photo</span></dt>
+    <dd class="rounded-all"><p>Photo upload data, encoded as multipart/form-data. The maximum file size allowed is 10MB</p></dd>
+  
+  </dl>
+  
+  <h3 id="uploadresponse" class="rounded-all">Response</h3>
+  <p>A successful request will respond with a Photo object
+If a successful photo upload is immediately accessible, a 201 Created status is returned, otherwise a 202 Accepted status is returned</p>
+  <dl>
+   
+    <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+    <dd class="rounded-all">
+    <p>A base url that can be use to construct a photo url from its components</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="caption"><span class="">caption</span></dt>
+    <dd class="rounded-all">
+    <p>Photo caption, if defined</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="comment_count"><span class="">comment_count</span></dt>
+    <dd class="rounded-all">
+    <p>The number of comments posted about this photo.
+Returned when 'comment_count' is present
+in the 'fields' request parameter.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo was uploaded, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>Group the photo is associated with." +
+          "|Returned when 'group' is present " +
+          "|in the 'fields' request parameter.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric group ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used generate group duotone</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Status of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for full sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric photo ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to photo on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>Member who uploaded the photo. If member has since left the group,
+this will return a member with an id of 0</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Intro of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+       <dd class="rounded-all">
+        <p>Member's context within the event. Only returned in the context of an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host"><span class="">host</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator for whether this member is a host for the event</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+    <dd class="rounded-all">
+    <p>Photo album the photo is associated with</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="event"><span class="">event</span></dt>
+       <dd class="rounded-all">
+        <p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric event ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of event</p></dd>
+            
+            <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of no RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="time"><span class="">time</span></dt>
+            <dd class="rounded-all"><p>UTC start time of the event, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+            <dd class="rounded-all"><p>The local offset from UTC time, in milliseconds</p></dd>
+            
+            <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+            <dd class="rounded-all"><p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of yes RSVPs</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for photo album</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of photos uploaded</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Album title</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for standard sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Context for the authenticated member.
+Returned when 'self' is present
+in the 'fields' request parameter and the authenticated
+is a member of the group the photo is associated with.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform on this photo
+or its containing album, potentially one or more of the following</p>
+<p>"comment" if member can comment on this photo</p>
+<p>"delete" if the member can delete the photo</p>
+<p>"edit" if the member can edit the photo details</p>
+<p>"upload_photo" if the member can upload new photos</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Shortened link to photo on meetup.com. Returned when 'short_link'
+is present in the 'fields' request parameter</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for thumbnail sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="type"><span class="">type</span></dt>
+    <dd class="rounded-all">
+    <p>Type of photo. One of "event" or "member"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo was last updated, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric utc offset based on the timezone of the group
+hosting the event this photo was posted in</p>
+    
+    </dd>
+  
+  </dl>
+  
+  <h4 id="uploaderrors" class="rounded-all">Errors</h4>
+  <dl>
+  
+    <dt class="align-right bold"><span class="">caption_error</span></dt>
+    <dd><p>The provided caption was longer than 255 characters</p></dd>
+  
+    <dt class="align-right bold"><span class="">photo_error</span></dt>
+    <dd><p>Returned photo was either omitted from the request or was invalid</p></dd>
+  
+    <dt class="align-right bold"><span class="">upload_error</span></dt>
+    <dd><p>The process of uploading the photo failed</p></dd>
+  
+    <dt class="align-right bold"><span class="">upload_limit_error</span></dt>
+    <dd><p>A member uploaded more photos than allowed for this event</p></dd>
+  
+    <dt class="align-right bold"><span class="">upload_timeout_error</span></dt>
+    <dd><p>A awaited response timed out</p></dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_photos.html
+++ b/test/data/_:urlname_photos.html
@@ -1,0 +1,453 @@
+
+        
+
+<div id="list">
+  <h2>Album Photos</h2>
+  <div id="listuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/photos
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Lists of all photos uploaded for the group</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/photos">Try it in the console</a></p>
+  <h3 id="listparams" class="rounded-all">Request Parameters</h3>
+  <div class="listparam-notes"><p>A valid path parameter for
+<strong>:urlname</strong> is required</p>
+<p>This endpoint uses HTTP <a href="/meetup_api/docs/#v3_json">Link header based pagination</a></p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="desc"><span class="">desc</span></dt>
+    <dd class="rounded-all"><p>Controls directional order or listing. Default false</p></dd>
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional response fields.
+Currently supported values are
+"comment_count", "self" and "short_link"</p></dd>
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>Number of items to return per-page of results. Defaults to 200</p></dd>
+  
+  </dl>
+  
+  <h3 id="listresponse" class="rounded-all">Response</h3>
+  <p>Returns a list of photo objects</p>
+  <dl>
+   
+    <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+    <dd class="rounded-all">
+    <p>A base url that can be use to construct a photo url from its components</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="caption"><span class="">caption</span></dt>
+    <dd class="rounded-all">
+    <p>Photo caption, if defined</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="comment_count"><span class="">comment_count</span></dt>
+    <dd class="rounded-all">
+    <p>The number of comments posted about this photo.
+Returned when 'comment_count' is present
+in the 'fields' request parameter.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo was uploaded, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>Group the photo is associated with." +
+          "|Returned when 'group' is present " +
+          "|in the 'fields' request parameter.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric group ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used generate group duotone</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Status of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for full sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric photo ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to photo on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>Member who uploaded the photo. If member has since left the group,
+this will return a member with an id of 0</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Intro of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+       <dd class="rounded-all">
+        <p>Member's context within the event. Only returned in the context of an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host"><span class="">host</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator for whether this member is a host for the event</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+    <dd class="rounded-all">
+    <p>Photo album the photo is associated with</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="event"><span class="">event</span></dt>
+       <dd class="rounded-all">
+        <p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric event ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of event</p></dd>
+            
+            <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of no RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="time"><span class="">time</span></dt>
+            <dd class="rounded-all"><p>UTC start time of the event, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+            <dd class="rounded-all"><p>The local offset from UTC time, in milliseconds</p></dd>
+            
+            <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+            <dd class="rounded-all"><p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of yes RSVPs</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for photo album</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of photos uploaded</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Album title</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for standard sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Context for the authenticated member.
+Returned when 'self' is present
+in the 'fields' request parameter and the authenticated
+is a member of the group the photo is associated with.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform on this photo
+or its containing album, potentially one or more of the following</p>
+<p>"comment" if member can comment on this photo</p>
+<p>"delete" if the member can delete the photo</p>
+<p>"edit" if the member can edit the photo details</p>
+<p>"upload_photo" if the member can upload new photos</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Shortened link to photo on meetup.com. Returned when 'short_link'
+is present in the 'fields' request parameter</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for thumbnail sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="type"><span class="">type</span></dt>
+    <dd class="rounded-all">
+    <p>Type of photo. One of "event" or "member"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Time photo was last updated, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric utc offset based on the timezone of the group
+hosting the event this photo was posted in</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_preferences_:domain.html
+++ b/test/data/_:urlname_preferences_:domain.html
@@ -1,0 +1,142 @@
+
+        
+
+<div id="">
+  <h2>Get preference and permission data</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/preferences/:domain
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Returns preference and permission data for the specified product domain</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/preferences/:domain">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>:urlname and :domain path parameters are required. :domain specifies the preference domain and must be one of: group_discussions.</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>400 BadRequest is returned if requesting data for an unsupported preference domain or if unauthenticated.
+500 InternalServerError is returned if an API error occurs.
+Otherwise, 200 Ok is returned.</p>
+  <dl>
+   
+    <dt class="align-right bold" title="preferences"><span class="">preferences</span></dt>
+    <dd class="rounded-all">
+    <p>Chapter preferences for the specified product domain</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Permissions for the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="permissions"><span class="">permissions</span></dt>
+       <dd class="rounded-all">
+        <p>Member permissions that pertain to the specified product domain</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="">
+  <h2>Update a preference</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">PATCH</strong> /:urlname/preferences/:domain
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Updates the specified preference for the specified product domain</p>
+  </div>
+  
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>:urlname and :domain path parameters are required.
+:domain specifies the preference domain and must be one of: group_discussions.
+The name of the preference to update is a required query string parameter.
+For the group_discussions domain, the only supported preference name is any_member_can_post</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>400 BadRequest is returned if attempting to update a preference for an unsupported domain,
+attempting to update an unsupported preference for a given domain, or if unauthenticated.
+401 Unauthorized is returned if the authenticated member does not have permission to update the specified preference.
+500 InternalServerError is returned if an API error occurs.
+Otherwise, 204 NoContent is returned.</p>
+  <dl>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_similar_groups.html
+++ b/test/data/_:urlname_similar_groups.html
@@ -1,0 +1,1233 @@
+
+        
+
+<div id="">
+  <h2>Similar groups</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /:urlname/similar_groups
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Renders a list of similar groups</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/:urlname/similar_groups">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>The :urlname path element may be any valid group urlname or domain name.</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>The response includes a JSON-encoded list of similar groups.</p>
+  <dl>
+   
+    <dt class="align-right bold" title="approved"><span class="">approved</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean indicator for whether this Group has been approved or not.
+New Groups are generally approved (or removed)
+soon after creation.
+Returned when the "fields" request parameter value includes
+"approved"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="category"><span class="">category</span></dt>
+    <dd class="rounded-all">
+    <p>The primary category of the group, if the group has one</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric category id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>String identifier of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name used for sorting</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city_link"><span class="">city_link</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, a URL for the group's city</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="contributions"><span class="">contributions</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field containing the contribution details of the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="enabled"><span class="">enabled</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean stating if contributions are enabled for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="potential"><span class="">potential</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean stating that potential contributions are enabled for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="reason"><span class="">reason</span></dt>
+       <dd class="rounded-all">
+        <p>The reason a member might consider contributing</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thanks"><span class="">thanks</span></dt>
+       <dd class="rounded-all">
+        <p>The 'thank you' message to be given when a contribution is made</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time the group was created in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>Short description of group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="discussion_preferences"><span class="">discussion_preferences</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field that contains preference and permission data for group discussions</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="draft_event_count"><span class="">draft_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of draft events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee_options"><span class="">fee_options</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, returns payment options for event ticketing</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currencies"><span class="">currencies</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable currencies for the payment method specified by type</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="code"><span class="">code</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="default"><span class="">default</span></dt>
+            <dd class="rounded-all"><p>A boolean set to true if the currency is the group's default currency, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="is_setup"><span class="">is_setup</span></dt>
+       <dd class="rounded-all">
+        <p>A boolean set to true if the payment method specified by 'type' is set up for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="setup_link"><span class="">setup_link</span></dt>
+       <dd class="rounded-all">
+        <p>The URL for setting up the payment method specified by 'type'. This is returned if the payment method specified by 'type' is not set up for the group and the member has the permission to set it up</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of Set(stripe, wepay, paypal, none, cash)</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Group photo</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric group ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_simplehtml"><span class="">is_simplehtml</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, 'true' when the group description has been saved in a simplified HTML format, 'false' otherwise.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_info"><span class="">join_info</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, lists any questions requested when joining and required fields</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="photo_req"><span class="">photo_req</span></dt>
+       <dd class="rounded-all">
+        <p>true if required, false otherwise</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="questions"><span class="">questions</span></dt>
+       <dd class="rounded-all">
+        <p>List of profile questions organizer would like new members to answer prior to joining</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the question</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>The text of the question</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="questions_req"><span class="">questions_req</span></dt>
+       <dd class="rounded-all">
+        <p>true if required, false otherwise</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+    <dd class="rounded-all">
+    <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Group primary photo</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+    <dd class="rounded-all">
+    <p>Lang of founder or coordinator</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="last_event"><span class="">last_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the last hosted event, if the group has one. Returned when the "fields" request parameter value contains "last_event"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Latitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="leader_limit"><span class="">leader_limit</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup leaders limit in group (4 leaders for the Basic Subscription), note this info available only for orgs and coorgs</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="leads"><span class="">leads</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the number of members on this group's leadership team. Returned when the "fields" request parameter value contains "leads"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to group on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="list_addr"><span class="">list_addr</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field returning list address prefix. List mail will be {list_addr}-list@meetup.com. Announce email will be {list_addr}-announce@meetup.com. You must be a member of the group to see this</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="list_mode"><span class="">list_mode</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the policy for who can post the group mailing list. Returned when the "fields" request parameter value contains "list_mode". Value may be one of "moderated", "off", "open", or "orgs_only"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+    <dd class="rounded-all">
+    <p>City/State or City/Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Longitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_cap"><span class="">member_cap</span></dt>
+    <dd class="rounded-all">
+    <p>Number representing the maximum number of active members this group can have if capped. Returned only when requested in the fields request parameter and the authenticated member has permission to approve members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_limit"><span class="">member_limit</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup members limit in group (now it's 50 members in the Basic Subscription)</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="members"><span class="">members</span></dt>
+    <dd class="rounded-all">
+    <p>Number of Meetup members in this group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, returns membership dues for group if any</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+       <dd class="rounded-all">
+        <p>Currency in which the fee is declared</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="dues_links"><span class="">dues_links</span></dt>
+       <dd class="rounded-all">
+        <p>Links to dues management and checkout pages.</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="checkout_url"><span class="">checkout_url</span></dt>
+            <dd class="rounded-all"><p>Dues checkout page URL</p></dd>
+            
+            <dt class="align-right bold" title="settings_url"><span class="">settings_url</span></dt>
+            <dd class="rounded-all"><p>(Organizers only) Dues settings page URL</p></dd>
+            
+            <dt class="align-right bold" title="start_url"><span class="">start_url</span></dt>
+            <dd class="rounded-all"><p>(Organizers only) Dues setup page URL</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric fee value</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee_desc"><span class="">fee_desc</span></dt>
+       <dd class="rounded-all">
+        <p>The interval at which dues must be paid. Possible values may include: "month", "year", "day", or "every other day"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="methods"><span class="">methods</span></dt>
+       <dd class="rounded-all">
+        <p>Methods of payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="amazon_payments"><span class="">amazon_payments</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Amazon Payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="credit_card"><span class="">credit_card</span></dt>
+            <dd class="rounded-all"><p>(Deprecated - use <code>wepay</code> or <code>stripe</code> instead) Boolean indicator that credit cards are accepted</p></dd>
+            
+            <dt class="align-right bold" title="other"><span class="">other</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that other forms of payment are accepted</p></dd>
+            
+            <dt class="align-right bold" title="paypal"><span class="">paypal</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Paypal payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="stripe"><span class="">stripe</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Stripe payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="wepay"><span class="">wepay</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Wepay payments are accepted</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="reasons"><span class="">reasons</span></dt>
+       <dd class="rounded-all">
+        <p>Array of reasons containing one or more of the following values compensate_organizer, cover_costs, encourage_engagement, improve_meetups, other, provide_supplies, reserve_fund</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="reasons_other"><span class="">reasons_other</span></dt>
+       <dd class="rounded-all">
+        <p>An additional reason if specified.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+       <dd class="rounded-all">
+        <p>Conditions for refunds</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="custom"><span class="">custom</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator of a custom refund policy</p></dd>
+            
+            <dt class="align-right bold" title="group_closes"><span class="">group_closes</span></dt>
+            <dd class="rounded-all"><p>refund applies when the group closes</p></dd>
+            
+            <dt class="align-right bold" title="member_banned"><span class="">member_banned</span></dt>
+            <dd class="rounded-all"><p>refund applies when the member is banned</p></dd>
+            
+            <dt class="align-right bold" title="member_leaves"><span class="">member_leaves</span></dt>
+            <dd class="rounded-all"><p>refund applies when member leaves the group</p></dd>
+            
+            <dt class="align-right bold" title="none"><span class="">none</span></dt>
+            <dd class="rounded-all"><p>indicates there is no refund policy</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="required"><span class="">required</span></dt>
+       <dd class="rounded-all">
+        <p>true if dues are required</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="required_to"><span class="">required_to</span></dt>
+       <dd class="rounded-all">
+        <p>If the dues are required this indicates what they are required for. Currently may only be 'join'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self_payment_required"><span class="">self_payment_required</span></dt>
+       <dd class="rounded-all">
+        <p>Returns true if the authorized user is prevented from participating in the group until a payment is made</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="trial_days"><span class="">trial_days</span></dt>
+       <dd class="rounded-all">
+        <p>When present, returns the number of days the group is offering a free trial period for to new members. When not present, this indicates that the group does not offer a trial membership period</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="meta_category"><span class="">meta_category</span></dt>
+    <dd class="rounded-all">
+    <p>The meta category of the group, if the group has one</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="best_topics"><span class="">best_topics</span></dt>
+       <dd class="rounded-all">
+        <p>Represents the best topic matches for this category, returned when the "fields"
+request parameter value includes "best_topics"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic id</p></dd>
+            
+            <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+            <dd class="rounded-all"><p>Language topic originates from</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic</p></dd>
+            
+            <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+            <dd class="rounded-all"><p>The unique keyword used to identify this topic</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="category_ids"><span class="">category_ids</span></dt>
+       <dd class="rounded-all">
+        <p>List of numeric category ids associated with this topic category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic-category id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic-category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Photo representing this category</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>Unique string identifier for this category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name used for sorting</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="next_event"><span class="">next_event</span></dt>
+    <dd class="rounded-all">
+    <p>The current ongoing or next upcoming event, if one is scheduled</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="nominated_member"><span class="">nominated_member</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns if the logged in member has been nominated to take over the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="organizer"><span class="">organizer</span></dt>
+    <dd class="rounded-all">
+    <p>Group's primary organizer</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Bio of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer photo, where defined</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="past_event_count"><span class="">past_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of past events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="pending_members"><span class="">pending_members</span></dt>
+    <dd class="rounded-all">
+    <p>Number representing the count of members pending organizer approval to join. Returned only when requested in the fields request parameter and the authenticated member has permission to approve members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+    <dd class="rounded-all">
+    <p>Color combination used generate group duotone</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+       <dd class="rounded-all">
+        <p>Composite color in hexidecimal format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+       <dd class="rounded-all">
+        <p>Dark color in hexidecimal format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+       <dd class="rounded-all">
+        <p>Light color in hexidecimal format</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photos"><span class="">photos</span></dt>
+    <dd class="rounded-all">
+    <p>A small set of photos from the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_description"><span class="">plain_text_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in plain text format. Returned when then "fields" request parameter value contains "plain_text_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_no_images_description"><span class="">plain_text_no_images_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in plain text format with no images. Returned when then "fields" request parameter value contains "plain_text_no_images_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="proposed_event_count"><span class="">proposed_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of proposed events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, contains details specific to the authorized user in this Meetup Group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform, potentially "broadcast_message": the ability to broadcast messages to group members via the "announce" mailing list, "event_create": the ability to create new events, "event_draft": the ability to save new events as drafts, "role_assign": the ability to assign member roles, "edit": the ability to edit group settings, "member_approval": the ability to approve or decline member requests to join, or "subscription_upgrade": the ability to upgrade this group's subscription plan</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Member's membership dues if the group has membership dues</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="cancelled"><span class="">cancelled</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that membership dues were cancelled</p></dd>
+            
+            <dt class="align-right bold" title="exempt"><span class="">exempt</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that the member is exempt from payment.</p></dd>
+            
+            <dt class="align-right bold" title="paid_until"><span class="">paid_until</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns the time in milliseconds since the epoch that the member's next payment is due</p></dd>
+            
+            <dt class="align-right bold" title="period_status"><span class="">period_status</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns one of the following values grace paid pending unpaid</p></dd>
+            
+            <dt class="align-right bold" title="total_amount"><span class="">total_amount</span></dt>
+            <dd class="rounded-all"><p>Total amount paid</p></dd>
+            
+            <dt class="align-right bold" title="transaction_time"><span class="">transaction_time</span></dt>
+            <dd class="rounded-all"><p>Time the transaction was made in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="trial"><span class="">trial</span></dt>
+            <dd class="rounded-all"><p>If the group offers a trial membership, this indicates information for unpaid members.</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="previous_membership_dues"><span class="">previous_membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Member's membership dues history when currently not a part of group i.e Status=none if the group has membership dues</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="cancelled"><span class="">cancelled</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that membership dues were cancelled</p></dd>
+            
+            <dt class="align-right bold" title="exempt"><span class="">exempt</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that the member is exempt from payment.</p></dd>
+            
+            <dt class="align-right bold" title="paid_until"><span class="">paid_until</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns the time in milliseconds since the epoch that the member's next payment is due</p></dd>
+            
+            <dt class="align-right bold" title="period_status"><span class="">period_status</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns one of the following values grace paid pending unpaid</p></dd>
+            
+            <dt class="align-right bold" title="total_amount"><span class="">total_amount</span></dt>
+            <dd class="rounded-all"><p>Total amount paid</p></dd>
+            
+            <dt class="align-right bold" title="transaction_time"><span class="">transaction_time</span></dt>
+            <dd class="rounded-all"><p>Time the transaction was made in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="trial"><span class="">trial</span></dt>
+            <dd class="rounded-all"><p>If the group offers a trial membership, this indicates information for unpaid members.</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>Member's role in group, if any: Organizer, Assistant Organizer, Event Organizer, etc.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Indicates the authorized user's membership with this group. Value may be one of "none", "pending", "pending_payment", "active", or "blocked"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+       <dd class="rounded-all">
+        <p>Member's last visit to the group site, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, a shorted URL for the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="similar_groups"><span class="">similar_groups</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns up to 5 groups similar to this groups, best suited for the authenticated member when a single group is queried for. Note: this field is being deprecated in favor of making a separate request to /:urlname/similar_groups</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Id of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photos"><span class="">photos</span></dt>
+       <dd class="rounded-all">
+        <p>Optional fields parameter. A small set of photos from the group</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What this group calls it's members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="simple_html_description"><span class="">simple_html_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in simple HTML source format. If this group's description was saved in simple HTML format, the description field will be an HTML translation of this source. Returned when the "fields" request parameter value contains "simple_html_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State of the group, if in US or Canada</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>Status of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+    <dd class="rounded-all">
+    <p>This represents the universal timezone identifier for the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the group's topics</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+       <dd class="rounded-all">
+        <p>Language topic originates from</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+       <dd class="rounded-all">
+        <p>The unique keyword used to identify this topic</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="untranslated_city"><span class="">untranslated_city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group, not translated</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="upcoming_event_count"><span class="">upcoming_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of upcoming events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+    <dd class="rounded-all">
+    <p>Urlname used to identify the group on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Who can see this group. One of members, public or public_limited</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="welcome_message"><span class="">welcome_message</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the Group's default welcome message if the authenticated member is the organizer of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="who"><span class="">who</span></dt>
+    <dd class="rounded-all">
+    <p>What the group calls its members</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_:urlname_topics.html
+++ b/test/data/_:urlname_topics.html
@@ -1,0 +1,2467 @@
+
+        
+
+<div id="add">
+  <h2>Group Topics Add</h2>
+  <div id="adduri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /:urlname/topics
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">group_edit</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Associates topics with a given Meetup group. Limited to organizers of the group. OAuth authenticated requests require an additional <a href="/meetup_api/auth/#oauth2-scopes">group_edit</a> permission.</p>
+  </div>
+  
+  <h3 id="addparams" class="rounded-all">Request Parameters</h3>
+  <div class="addparam-notes"><p>A group can have at most 15 topics</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="topic_id"><span class="param_required">topic_id</span></dt>
+    <dd class="rounded-all"><p>Comma-delimited list of topic ids to associate with group</p></dd>
+  
+  </dl>
+  
+  <h3 id="addresponse" class="rounded-all">Response</h3>
+  <p>A successful response will include a representation of the group topics were added to</p>
+  <dl>
+   
+    <dt class="align-right bold" title="approved"><span class="">approved</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean indicator for whether this Group has been approved or not.
+New Groups are generally approved (or removed)
+soon after creation.
+Returned when the "fields" request parameter value includes
+"approved"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="category"><span class="">category</span></dt>
+    <dd class="rounded-all">
+    <p>The primary category of the group, if the group has one</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric category id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>String identifier of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name used for sorting</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city_link"><span class="">city_link</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, a URL for the group's city</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="contributions"><span class="">contributions</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field containing the contribution details of the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="enabled"><span class="">enabled</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean stating if contributions are enabled for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="potential"><span class="">potential</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean stating that potential contributions are enabled for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="reason"><span class="">reason</span></dt>
+       <dd class="rounded-all">
+        <p>The reason a member might consider contributing</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thanks"><span class="">thanks</span></dt>
+       <dd class="rounded-all">
+        <p>The 'thank you' message to be given when a contribution is made</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time the group was created in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>Short description of group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="discussion_preferences"><span class="">discussion_preferences</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field that contains preference and permission data for group discussions</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="draft_event_count"><span class="">draft_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of draft events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee_options"><span class="">fee_options</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, returns payment options for event ticketing</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currencies"><span class="">currencies</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable currencies for the payment method specified by type</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="code"><span class="">code</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="default"><span class="">default</span></dt>
+            <dd class="rounded-all"><p>A boolean set to true if the currency is the group's default currency, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="is_setup"><span class="">is_setup</span></dt>
+       <dd class="rounded-all">
+        <p>A boolean set to true if the payment method specified by 'type' is set up for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="setup_link"><span class="">setup_link</span></dt>
+       <dd class="rounded-all">
+        <p>The URL for setting up the payment method specified by 'type'. This is returned if the payment method specified by 'type' is not set up for the group and the member has the permission to set it up</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of Set(stripe, wepay, paypal, none, cash)</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Group photo</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric group ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_simplehtml"><span class="">is_simplehtml</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, 'true' when the group description has been saved in a simplified HTML format, 'false' otherwise.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_info"><span class="">join_info</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, lists any questions requested when joining and required fields</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="photo_req"><span class="">photo_req</span></dt>
+       <dd class="rounded-all">
+        <p>true if required, false otherwise</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="questions"><span class="">questions</span></dt>
+       <dd class="rounded-all">
+        <p>List of profile questions organizer would like new members to answer prior to joining</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the question</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>The text of the question</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="questions_req"><span class="">questions_req</span></dt>
+       <dd class="rounded-all">
+        <p>true if required, false otherwise</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+    <dd class="rounded-all">
+    <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Group primary photo</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+    <dd class="rounded-all">
+    <p>Lang of founder or coordinator</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="last_event"><span class="">last_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the last hosted event, if the group has one. Returned when the "fields" request parameter value contains "last_event"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Latitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="leader_limit"><span class="">leader_limit</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup leaders limit in group (4 leaders for the Basic Subscription), note this info available only for orgs and coorgs</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="leads"><span class="">leads</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the number of members on this group's leadership team. Returned when the "fields" request parameter value contains "leads"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to group on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="list_addr"><span class="">list_addr</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field returning list address prefix. List mail will be {list_addr}-list@meetup.com. Announce email will be {list_addr}-announce@meetup.com. You must be a member of the group to see this</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="list_mode"><span class="">list_mode</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the policy for who can post the group mailing list. Returned when the "fields" request parameter value contains "list_mode". Value may be one of "moderated", "off", "open", or "orgs_only"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+    <dd class="rounded-all">
+    <p>City/State or City/Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Longitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_cap"><span class="">member_cap</span></dt>
+    <dd class="rounded-all">
+    <p>Number representing the maximum number of active members this group can have if capped. Returned only when requested in the fields request parameter and the authenticated member has permission to approve members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_limit"><span class="">member_limit</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup members limit in group (now it's 50 members in the Basic Subscription)</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="members"><span class="">members</span></dt>
+    <dd class="rounded-all">
+    <p>Number of Meetup members in this group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, returns membership dues for group if any</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+       <dd class="rounded-all">
+        <p>Currency in which the fee is declared</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="dues_links"><span class="">dues_links</span></dt>
+       <dd class="rounded-all">
+        <p>Links to dues management and checkout pages.</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="checkout_url"><span class="">checkout_url</span></dt>
+            <dd class="rounded-all"><p>Dues checkout page URL</p></dd>
+            
+            <dt class="align-right bold" title="settings_url"><span class="">settings_url</span></dt>
+            <dd class="rounded-all"><p>(Organizers only) Dues settings page URL</p></dd>
+            
+            <dt class="align-right bold" title="start_url"><span class="">start_url</span></dt>
+            <dd class="rounded-all"><p>(Organizers only) Dues setup page URL</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric fee value</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee_desc"><span class="">fee_desc</span></dt>
+       <dd class="rounded-all">
+        <p>The interval at which dues must be paid. Possible values may include: "month", "year", "day", or "every other day"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="methods"><span class="">methods</span></dt>
+       <dd class="rounded-all">
+        <p>Methods of payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="amazon_payments"><span class="">amazon_payments</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Amazon Payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="credit_card"><span class="">credit_card</span></dt>
+            <dd class="rounded-all"><p>(Deprecated - use <code>wepay</code> or <code>stripe</code> instead) Boolean indicator that credit cards are accepted</p></dd>
+            
+            <dt class="align-right bold" title="other"><span class="">other</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that other forms of payment are accepted</p></dd>
+            
+            <dt class="align-right bold" title="paypal"><span class="">paypal</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Paypal payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="stripe"><span class="">stripe</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Stripe payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="wepay"><span class="">wepay</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Wepay payments are accepted</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="reasons"><span class="">reasons</span></dt>
+       <dd class="rounded-all">
+        <p>Array of reasons containing one or more of the following values compensate_organizer, cover_costs, encourage_engagement, improve_meetups, other, provide_supplies, reserve_fund</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="reasons_other"><span class="">reasons_other</span></dt>
+       <dd class="rounded-all">
+        <p>An additional reason if specified.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+       <dd class="rounded-all">
+        <p>Conditions for refunds</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="custom"><span class="">custom</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator of a custom refund policy</p></dd>
+            
+            <dt class="align-right bold" title="group_closes"><span class="">group_closes</span></dt>
+            <dd class="rounded-all"><p>refund applies when the group closes</p></dd>
+            
+            <dt class="align-right bold" title="member_banned"><span class="">member_banned</span></dt>
+            <dd class="rounded-all"><p>refund applies when the member is banned</p></dd>
+            
+            <dt class="align-right bold" title="member_leaves"><span class="">member_leaves</span></dt>
+            <dd class="rounded-all"><p>refund applies when member leaves the group</p></dd>
+            
+            <dt class="align-right bold" title="none"><span class="">none</span></dt>
+            <dd class="rounded-all"><p>indicates there is no refund policy</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="required"><span class="">required</span></dt>
+       <dd class="rounded-all">
+        <p>true if dues are required</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="required_to"><span class="">required_to</span></dt>
+       <dd class="rounded-all">
+        <p>If the dues are required this indicates what they are required for. Currently may only be 'join'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self_payment_required"><span class="">self_payment_required</span></dt>
+       <dd class="rounded-all">
+        <p>Returns true if the authorized user is prevented from participating in the group until a payment is made</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="trial_days"><span class="">trial_days</span></dt>
+       <dd class="rounded-all">
+        <p>When present, returns the number of days the group is offering a free trial period for to new members. When not present, this indicates that the group does not offer a trial membership period</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="meta_category"><span class="">meta_category</span></dt>
+    <dd class="rounded-all">
+    <p>The meta category of the group, if the group has one</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="best_topics"><span class="">best_topics</span></dt>
+       <dd class="rounded-all">
+        <p>Represents the best topic matches for this category, returned when the "fields"
+request parameter value includes "best_topics"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic id</p></dd>
+            
+            <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+            <dd class="rounded-all"><p>Language topic originates from</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic</p></dd>
+            
+            <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+            <dd class="rounded-all"><p>The unique keyword used to identify this topic</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="category_ids"><span class="">category_ids</span></dt>
+       <dd class="rounded-all">
+        <p>List of numeric category ids associated with this topic category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic-category id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic-category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Photo representing this category</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>Unique string identifier for this category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name used for sorting</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="next_event"><span class="">next_event</span></dt>
+    <dd class="rounded-all">
+    <p>The current ongoing or next upcoming event, if one is scheduled</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="nominated_member"><span class="">nominated_member</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns if the logged in member has been nominated to take over the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="organizer"><span class="">organizer</span></dt>
+    <dd class="rounded-all">
+    <p>Group's primary organizer</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Bio of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer photo, where defined</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="past_event_count"><span class="">past_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of past events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="pending_members"><span class="">pending_members</span></dt>
+    <dd class="rounded-all">
+    <p>Number representing the count of members pending organizer approval to join. Returned only when requested in the fields request parameter and the authenticated member has permission to approve members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+    <dd class="rounded-all">
+    <p>Color combination used generate group duotone</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+       <dd class="rounded-all">
+        <p>Composite color in hexidecimal format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+       <dd class="rounded-all">
+        <p>Dark color in hexidecimal format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+       <dd class="rounded-all">
+        <p>Light color in hexidecimal format</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photos"><span class="">photos</span></dt>
+    <dd class="rounded-all">
+    <p>A small set of photos from the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_description"><span class="">plain_text_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in plain text format. Returned when then "fields" request parameter value contains "plain_text_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_no_images_description"><span class="">plain_text_no_images_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in plain text format with no images. Returned when then "fields" request parameter value contains "plain_text_no_images_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="proposed_event_count"><span class="">proposed_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of proposed events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, contains details specific to the authorized user in this Meetup Group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform, potentially "broadcast_message": the ability to broadcast messages to group members via the "announce" mailing list, "event_create": the ability to create new events, "event_draft": the ability to save new events as drafts, "role_assign": the ability to assign member roles, "edit": the ability to edit group settings, "member_approval": the ability to approve or decline member requests to join, or "subscription_upgrade": the ability to upgrade this group's subscription plan</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Member's membership dues if the group has membership dues</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="cancelled"><span class="">cancelled</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that membership dues were cancelled</p></dd>
+            
+            <dt class="align-right bold" title="exempt"><span class="">exempt</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that the member is exempt from payment.</p></dd>
+            
+            <dt class="align-right bold" title="paid_until"><span class="">paid_until</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns the time in milliseconds since the epoch that the member's next payment is due</p></dd>
+            
+            <dt class="align-right bold" title="period_status"><span class="">period_status</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns one of the following values grace paid pending unpaid</p></dd>
+            
+            <dt class="align-right bold" title="total_amount"><span class="">total_amount</span></dt>
+            <dd class="rounded-all"><p>Total amount paid</p></dd>
+            
+            <dt class="align-right bold" title="transaction_time"><span class="">transaction_time</span></dt>
+            <dd class="rounded-all"><p>Time the transaction was made in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="trial"><span class="">trial</span></dt>
+            <dd class="rounded-all"><p>If the group offers a trial membership, this indicates information for unpaid members.</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="previous_membership_dues"><span class="">previous_membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Member's membership dues history when currently not a part of group i.e Status=none if the group has membership dues</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="cancelled"><span class="">cancelled</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that membership dues were cancelled</p></dd>
+            
+            <dt class="align-right bold" title="exempt"><span class="">exempt</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that the member is exempt from payment.</p></dd>
+            
+            <dt class="align-right bold" title="paid_until"><span class="">paid_until</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns the time in milliseconds since the epoch that the member's next payment is due</p></dd>
+            
+            <dt class="align-right bold" title="period_status"><span class="">period_status</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns one of the following values grace paid pending unpaid</p></dd>
+            
+            <dt class="align-right bold" title="total_amount"><span class="">total_amount</span></dt>
+            <dd class="rounded-all"><p>Total amount paid</p></dd>
+            
+            <dt class="align-right bold" title="transaction_time"><span class="">transaction_time</span></dt>
+            <dd class="rounded-all"><p>Time the transaction was made in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="trial"><span class="">trial</span></dt>
+            <dd class="rounded-all"><p>If the group offers a trial membership, this indicates information for unpaid members.</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>Member's role in group, if any: Organizer, Assistant Organizer, Event Organizer, etc.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Indicates the authorized user's membership with this group. Value may be one of "none", "pending", "pending_payment", "active", or "blocked"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+       <dd class="rounded-all">
+        <p>Member's last visit to the group site, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, a shorted URL for the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="similar_groups"><span class="">similar_groups</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns up to 5 groups similar to this groups, best suited for the authenticated member when a single group is queried for. Note: this field is being deprecated in favor of making a separate request to /:urlname/similar_groups</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Id of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photos"><span class="">photos</span></dt>
+       <dd class="rounded-all">
+        <p>Optional fields parameter. A small set of photos from the group</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What this group calls it's members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="simple_html_description"><span class="">simple_html_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in simple HTML source format. If this group's description was saved in simple HTML format, the description field will be an HTML translation of this source. Returned when the "fields" request parameter value contains "simple_html_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State of the group, if in US or Canada</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>Status of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+    <dd class="rounded-all">
+    <p>This represents the universal timezone identifier for the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the group's topics</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+       <dd class="rounded-all">
+        <p>Language topic originates from</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+       <dd class="rounded-all">
+        <p>The unique keyword used to identify this topic</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="untranslated_city"><span class="">untranslated_city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group, not translated</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="upcoming_event_count"><span class="">upcoming_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of upcoming events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+    <dd class="rounded-all">
+    <p>Urlname used to identify the group on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Who can see this group. One of members, public or public_limited</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="welcome_message"><span class="">welcome_message</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the Group's default welcome message if the authenticated member is the organizer of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="who"><span class="">who</span></dt>
+    <dd class="rounded-all">
+    <p>What the group calls its members</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="remove">
+  <h2>Group Topics Remove</h2>
+  <div id="removeuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">DELETE</strong> /:urlname/topics
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">group_edit</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Disassociates topics with a given Meetup group. Limited to organizers of the group. OAuth authenticated requests require an additional <a href="/meetup_api/auth/#oauth2-scopes">group_edit</a> permission.</p>
+  </div>
+  
+  <h3 id="removeparams" class="rounded-all">Request Parameters</h3>
+  <div class="removeparam-notes"><p>Groups must have at least one topic. Attempts to remove all topics will result in a failed request</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="topic_id"><span class="param_required">topic_id</span></dt>
+    <dd class="rounded-all"><p>Comma-delimited list of topic ids to disassociate with group</p></dd>
+  
+  </dl>
+  
+  <h3 id="removeresponse" class="rounded-all">Response</h3>
+  <p>A successful response will include a representation of the group topics were removed from</p>
+  <dl>
+   
+    <dt class="align-right bold" title="approved"><span class="">approved</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean indicator for whether this Group has been approved or not.
+New Groups are generally approved (or removed)
+soon after creation.
+Returned when the "fields" request parameter value includes
+"approved"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="category"><span class="">category</span></dt>
+    <dd class="rounded-all">
+    <p>The primary category of the group, if the group has one</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric category id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>String identifier of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name used for sorting</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city_link"><span class="">city_link</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, a URL for the group's city</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="contributions"><span class="">contributions</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field containing the contribution details of the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="enabled"><span class="">enabled</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean stating if contributions are enabled for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="potential"><span class="">potential</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean stating that potential contributions are enabled for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="reason"><span class="">reason</span></dt>
+       <dd class="rounded-all">
+        <p>The reason a member might consider contributing</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thanks"><span class="">thanks</span></dt>
+       <dd class="rounded-all">
+        <p>The 'thank you' message to be given when a contribution is made</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time the group was created in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>Short description of group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="discussion_preferences"><span class="">discussion_preferences</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field that contains preference and permission data for group discussions</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="draft_event_count"><span class="">draft_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of draft events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee_options"><span class="">fee_options</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, returns payment options for event ticketing</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currencies"><span class="">currencies</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable currencies for the payment method specified by type</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="code"><span class="">code</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="default"><span class="">default</span></dt>
+            <dd class="rounded-all"><p>A boolean set to true if the currency is the group's default currency, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="is_setup"><span class="">is_setup</span></dt>
+       <dd class="rounded-all">
+        <p>A boolean set to true if the payment method specified by 'type' is set up for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="setup_link"><span class="">setup_link</span></dt>
+       <dd class="rounded-all">
+        <p>The URL for setting up the payment method specified by 'type'. This is returned if the payment method specified by 'type' is not set up for the group and the member has the permission to set it up</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of Set(stripe, wepay, paypal, none, cash)</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Group photo</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric group ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_simplehtml"><span class="">is_simplehtml</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, 'true' when the group description has been saved in a simplified HTML format, 'false' otherwise.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_info"><span class="">join_info</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, lists any questions requested when joining and required fields</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="photo_req"><span class="">photo_req</span></dt>
+       <dd class="rounded-all">
+        <p>true if required, false otherwise</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="questions"><span class="">questions</span></dt>
+       <dd class="rounded-all">
+        <p>List of profile questions organizer would like new members to answer prior to joining</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the question</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>The text of the question</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="questions_req"><span class="">questions_req</span></dt>
+       <dd class="rounded-all">
+        <p>true if required, false otherwise</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+    <dd class="rounded-all">
+    <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Group primary photo</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+    <dd class="rounded-all">
+    <p>Lang of founder or coordinator</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="last_event"><span class="">last_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the last hosted event, if the group has one. Returned when the "fields" request parameter value contains "last_event"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Latitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="leader_limit"><span class="">leader_limit</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup leaders limit in group (4 leaders for the Basic Subscription), note this info available only for orgs and coorgs</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="leads"><span class="">leads</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the number of members on this group's leadership team. Returned when the "fields" request parameter value contains "leads"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to group on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="list_addr"><span class="">list_addr</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field returning list address prefix. List mail will be {list_addr}-list@meetup.com. Announce email will be {list_addr}-announce@meetup.com. You must be a member of the group to see this</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="list_mode"><span class="">list_mode</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the policy for who can post the group mailing list. Returned when the "fields" request parameter value contains "list_mode". Value may be one of "moderated", "off", "open", or "orgs_only"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+    <dd class="rounded-all">
+    <p>City/State or City/Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Longitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_cap"><span class="">member_cap</span></dt>
+    <dd class="rounded-all">
+    <p>Number representing the maximum number of active members this group can have if capped. Returned only when requested in the fields request parameter and the authenticated member has permission to approve members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_limit"><span class="">member_limit</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup members limit in group (now it's 50 members in the Basic Subscription)</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="members"><span class="">members</span></dt>
+    <dd class="rounded-all">
+    <p>Number of Meetup members in this group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, returns membership dues for group if any</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+       <dd class="rounded-all">
+        <p>Currency in which the fee is declared</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="dues_links"><span class="">dues_links</span></dt>
+       <dd class="rounded-all">
+        <p>Links to dues management and checkout pages.</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="checkout_url"><span class="">checkout_url</span></dt>
+            <dd class="rounded-all"><p>Dues checkout page URL</p></dd>
+            
+            <dt class="align-right bold" title="settings_url"><span class="">settings_url</span></dt>
+            <dd class="rounded-all"><p>(Organizers only) Dues settings page URL</p></dd>
+            
+            <dt class="align-right bold" title="start_url"><span class="">start_url</span></dt>
+            <dd class="rounded-all"><p>(Organizers only) Dues setup page URL</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric fee value</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee_desc"><span class="">fee_desc</span></dt>
+       <dd class="rounded-all">
+        <p>The interval at which dues must be paid. Possible values may include: "month", "year", "day", or "every other day"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="methods"><span class="">methods</span></dt>
+       <dd class="rounded-all">
+        <p>Methods of payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="amazon_payments"><span class="">amazon_payments</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Amazon Payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="credit_card"><span class="">credit_card</span></dt>
+            <dd class="rounded-all"><p>(Deprecated - use <code>wepay</code> or <code>stripe</code> instead) Boolean indicator that credit cards are accepted</p></dd>
+            
+            <dt class="align-right bold" title="other"><span class="">other</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that other forms of payment are accepted</p></dd>
+            
+            <dt class="align-right bold" title="paypal"><span class="">paypal</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Paypal payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="stripe"><span class="">stripe</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Stripe payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="wepay"><span class="">wepay</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Wepay payments are accepted</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="reasons"><span class="">reasons</span></dt>
+       <dd class="rounded-all">
+        <p>Array of reasons containing one or more of the following values compensate_organizer, cover_costs, encourage_engagement, improve_meetups, other, provide_supplies, reserve_fund</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="reasons_other"><span class="">reasons_other</span></dt>
+       <dd class="rounded-all">
+        <p>An additional reason if specified.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+       <dd class="rounded-all">
+        <p>Conditions for refunds</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="custom"><span class="">custom</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator of a custom refund policy</p></dd>
+            
+            <dt class="align-right bold" title="group_closes"><span class="">group_closes</span></dt>
+            <dd class="rounded-all"><p>refund applies when the group closes</p></dd>
+            
+            <dt class="align-right bold" title="member_banned"><span class="">member_banned</span></dt>
+            <dd class="rounded-all"><p>refund applies when the member is banned</p></dd>
+            
+            <dt class="align-right bold" title="member_leaves"><span class="">member_leaves</span></dt>
+            <dd class="rounded-all"><p>refund applies when member leaves the group</p></dd>
+            
+            <dt class="align-right bold" title="none"><span class="">none</span></dt>
+            <dd class="rounded-all"><p>indicates there is no refund policy</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="required"><span class="">required</span></dt>
+       <dd class="rounded-all">
+        <p>true if dues are required</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="required_to"><span class="">required_to</span></dt>
+       <dd class="rounded-all">
+        <p>If the dues are required this indicates what they are required for. Currently may only be 'join'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self_payment_required"><span class="">self_payment_required</span></dt>
+       <dd class="rounded-all">
+        <p>Returns true if the authorized user is prevented from participating in the group until a payment is made</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="trial_days"><span class="">trial_days</span></dt>
+       <dd class="rounded-all">
+        <p>When present, returns the number of days the group is offering a free trial period for to new members. When not present, this indicates that the group does not offer a trial membership period</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="meta_category"><span class="">meta_category</span></dt>
+    <dd class="rounded-all">
+    <p>The meta category of the group, if the group has one</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="best_topics"><span class="">best_topics</span></dt>
+       <dd class="rounded-all">
+        <p>Represents the best topic matches for this category, returned when the "fields"
+request parameter value includes "best_topics"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic id</p></dd>
+            
+            <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+            <dd class="rounded-all"><p>Language topic originates from</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic</p></dd>
+            
+            <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+            <dd class="rounded-all"><p>The unique keyword used to identify this topic</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="category_ids"><span class="">category_ids</span></dt>
+       <dd class="rounded-all">
+        <p>List of numeric category ids associated with this topic category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic-category id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic-category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Photo representing this category</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>Unique string identifier for this category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name used for sorting</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="next_event"><span class="">next_event</span></dt>
+    <dd class="rounded-all">
+    <p>The current ongoing or next upcoming event, if one is scheduled</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="nominated_member"><span class="">nominated_member</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns if the logged in member has been nominated to take over the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="organizer"><span class="">organizer</span></dt>
+    <dd class="rounded-all">
+    <p>Group's primary organizer</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Bio of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer photo, where defined</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="past_event_count"><span class="">past_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of past events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="pending_members"><span class="">pending_members</span></dt>
+    <dd class="rounded-all">
+    <p>Number representing the count of members pending organizer approval to join. Returned only when requested in the fields request parameter and the authenticated member has permission to approve members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+    <dd class="rounded-all">
+    <p>Color combination used generate group duotone</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+       <dd class="rounded-all">
+        <p>Composite color in hexidecimal format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+       <dd class="rounded-all">
+        <p>Dark color in hexidecimal format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+       <dd class="rounded-all">
+        <p>Light color in hexidecimal format</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photos"><span class="">photos</span></dt>
+    <dd class="rounded-all">
+    <p>A small set of photos from the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_description"><span class="">plain_text_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in plain text format. Returned when then "fields" request parameter value contains "plain_text_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_no_images_description"><span class="">plain_text_no_images_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in plain text format with no images. Returned when then "fields" request parameter value contains "plain_text_no_images_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="proposed_event_count"><span class="">proposed_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of proposed events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, contains details specific to the authorized user in this Meetup Group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform, potentially "broadcast_message": the ability to broadcast messages to group members via the "announce" mailing list, "event_create": the ability to create new events, "event_draft": the ability to save new events as drafts, "role_assign": the ability to assign member roles, "edit": the ability to edit group settings, "member_approval": the ability to approve or decline member requests to join, or "subscription_upgrade": the ability to upgrade this group's subscription plan</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Member's membership dues if the group has membership dues</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="cancelled"><span class="">cancelled</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that membership dues were cancelled</p></dd>
+            
+            <dt class="align-right bold" title="exempt"><span class="">exempt</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that the member is exempt from payment.</p></dd>
+            
+            <dt class="align-right bold" title="paid_until"><span class="">paid_until</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns the time in milliseconds since the epoch that the member's next payment is due</p></dd>
+            
+            <dt class="align-right bold" title="period_status"><span class="">period_status</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns one of the following values grace paid pending unpaid</p></dd>
+            
+            <dt class="align-right bold" title="total_amount"><span class="">total_amount</span></dt>
+            <dd class="rounded-all"><p>Total amount paid</p></dd>
+            
+            <dt class="align-right bold" title="transaction_time"><span class="">transaction_time</span></dt>
+            <dd class="rounded-all"><p>Time the transaction was made in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="trial"><span class="">trial</span></dt>
+            <dd class="rounded-all"><p>If the group offers a trial membership, this indicates information for unpaid members.</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="previous_membership_dues"><span class="">previous_membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Member's membership dues history when currently not a part of group i.e Status=none if the group has membership dues</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="cancelled"><span class="">cancelled</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that membership dues were cancelled</p></dd>
+            
+            <dt class="align-right bold" title="exempt"><span class="">exempt</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that the member is exempt from payment.</p></dd>
+            
+            <dt class="align-right bold" title="paid_until"><span class="">paid_until</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns the time in milliseconds since the epoch that the member's next payment is due</p></dd>
+            
+            <dt class="align-right bold" title="period_status"><span class="">period_status</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns one of the following values grace paid pending unpaid</p></dd>
+            
+            <dt class="align-right bold" title="total_amount"><span class="">total_amount</span></dt>
+            <dd class="rounded-all"><p>Total amount paid</p></dd>
+            
+            <dt class="align-right bold" title="transaction_time"><span class="">transaction_time</span></dt>
+            <dd class="rounded-all"><p>Time the transaction was made in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="trial"><span class="">trial</span></dt>
+            <dd class="rounded-all"><p>If the group offers a trial membership, this indicates information for unpaid members.</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>Member's role in group, if any: Organizer, Assistant Organizer, Event Organizer, etc.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Indicates the authorized user's membership with this group. Value may be one of "none", "pending", "pending_payment", "active", or "blocked"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+       <dd class="rounded-all">
+        <p>Member's last visit to the group site, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, a shorted URL for the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="similar_groups"><span class="">similar_groups</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns up to 5 groups similar to this groups, best suited for the authenticated member when a single group is queried for. Note: this field is being deprecated in favor of making a separate request to /:urlname/similar_groups</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Id of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photos"><span class="">photos</span></dt>
+       <dd class="rounded-all">
+        <p>Optional fields parameter. A small set of photos from the group</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What this group calls it's members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="simple_html_description"><span class="">simple_html_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in simple HTML source format. If this group's description was saved in simple HTML format, the description field will be an HTML translation of this source. Returned when the "fields" request parameter value contains "simple_html_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State of the group, if in US or Canada</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>Status of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+    <dd class="rounded-all">
+    <p>This represents the universal timezone identifier for the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the group's topics</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+       <dd class="rounded-all">
+        <p>Language topic originates from</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+       <dd class="rounded-all">
+        <p>The unique keyword used to identify this topic</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="untranslated_city"><span class="">untranslated_city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group, not translated</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="upcoming_event_count"><span class="">upcoming_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of upcoming events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+    <dd class="rounded-all">
+    <p>Urlname used to identify the group on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Who can see this group. One of members, public or public_limited</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="welcome_message"><span class="">welcome_message</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the Group's default welcome message if the authenticated member is the organizer of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="who"><span class="">who</span></dt>
+    <dd class="rounded-all">
+    <p>What the group calls its members</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_batch.html
+++ b/test/data/_batch.html
@@ -1,0 +1,140 @@
+
+        
+
+<div id="">
+  <h2>batch</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /batch
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Performs multiple API requests in batch, useful for reducing HTTP network requests. This method is only available for OAuth authentication</p>
+  </div>
+  
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>You may supply a limited number of API requests, typically 1 to 4, in one batch request using the required "requests" parameter.
+ Each of these individual batched requests will be tallied separately the same way they would when making individual requests.
+ The batch request itself will not be tallied. As such, batch requests can not be rate limited.
+ The only failures that you should account for are an authentication failure or a malformed JSON encoding of requests provided with the "requests" parameter.</p>
+<h4>Composing batch requests</h4>
+<p>Requests should be provided within a JSON-encoded array in the following format attached the <code>requests</code> parameter
+ within a POST body</p>
+<pre> [{
+   "path": "/members/self",
+   "ref":  "me",
+   "params": {
+     "only": "name,id"
+   }
+ }]
+</pre>
+
+<p>Only "path" is required for HTTP GET requests. "path" represents the API path for the method. "ref" provides a way to tag a request in a batch
+ with a label that you can associated with its response in the body of the batch response. This will default to the
+ provided "path". You may also supply a "params" key with a JSON object representing the parameters provided for the
+ request. At this time only HTTP GET, DELETE, and POST requests are supported. You may specify one of these as a "method" property of the request.
+ Methods requiring a multipart form POST are currently not supported. You may also supply headers on a per request basis by adding a "headers" field to the
+ JSON object representing the request as key value pairs of strings.</p>
+<h4>Interpreting batch responses</h4>
+<p>A response to a batch request will be in the format</p>
+<pre> [{
+   "path": "/member/self"
+   "status": 200,
+   "ref": "me",
+   "body": {
+     "id": 1234,
+     "name": "Noah"
+   },
+   "headers": {
+     "key": "value"
+    }
+ }]
+</pre>
+
+<p>"path" is the path of the method invoked. "status" represents the HTTP status code returned for the request.
+ "ref" is the name provided for the inbound request. "body" is the JSON-encoded response from the given API request.
+ "headers" is a JSON-encoded object representing the headers returned for that request.
+ These requests may fail the same way they would when making individual requests. The response will indicate these
+ failures.</p>
+<p>In order to preserve server resources and return batch responses within a reasonable amount of time, individual requests may timeout
+ if a response is not computed within a reasonable amount of time. This allows for some requests to fail and others to pass which is a nicer
+ alternative to an all or nothing response timeout.
+ A timed out request can be identified by inspecting its response's "status" field for a value of 504. A timed out response may look like.</p>
+<pre> [{
+   "status" : 504,
+   "body" : {
+    "errors" : [{"code": "request_timeout", "message":"request timed out"}]
+   },
+   "headers" : { ... },
+   "path" : "/end/point",
+   "ref" : "request_ref"
+ }]
+</pre></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="requests"><span class="param_required">requests</span></dt>
+    <dd class="rounded-all"><p>JSON-encoding of multiple request objects as described in the parameter notes</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>The response will be a JSON-encoded array of responses to requests defined in the batch request</p>
+  <dl>
+  
+  </dl>
+  
+  
+  <h3 id="examples" class="rounded-all">Examples</h3>
+  <p>Below is an example of making batch request issued by the command line program, curl</p>
+<pre># define a file containing the request body containing the requests to execute
+cat batch.requests
+requests=[{
+  "path":"/members/self"
+},{
+  "path": "/self/events",
+  "params": {
+    "rsvp": "yes",
+    "only":"name,local_time"
+  }
+}]
+
+# perform an HTTP POST request with the body set to the contents of the batch.requests file
+curl -H "Authorization: Bearer $OAUTH2_ACCESS_TOKEN" https://api.meetup.com/batch -d @batch.requests
+</pre>
+
+<p>You may also discard fields as you can do with any other method. Below is an example of only fetching the bodies of the responses
+ to the requests.</p>
+<pre>curl -H "Authorization: Bearer $OAUTH2_ACCESS_TOKEN" https://api.meetup.com/batch?only=body -d @batch.requests
+</pre>
+  
+</div>
+
+
+      

--- a/test/data/_find_:urlname_members.html
+++ b/test/data/_find_:urlname_members.html
@@ -1,0 +1,481 @@
+
+        
+
+<div id="">
+  <h2>Group Profile search</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /find/:urlname/members
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Find group member profiles by name.
+Member's who very recently joined or left the group may not be immediately searchable</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/find/:urlname/members">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>A valid <strong>:urlname</strong> path parameter is required</p>
+<p>This endpoint uses HTTP <a href="/meetup_api/docs/#v3_json">Link header based pagination</a>.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional fields to append to the response</p></dd>
+  
+    <dt class="align-right bold" title="order"><span class="">order</span></dt>
+    <dd class="rounded-all"><p>Orders results according to definitions listed below. May be one of "name" or "closest_match"</p></dd>
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>Number of requested members to return. Defaults to 50</p></dd>
+  
+    <dt class="align-right bold" title="query"><span class="param_required">query</span></dt>
+    <dd class="rounded-all"><p>The name to search for</p></dd>
+  
+  </dl>
+  
+  <h4 id="ordering">Ordering</h4>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold"><span class="">closest_match</span></dt>
+    <dd class="rounded-all"><p>Ordered by closest match to the provided query</p></dd>
+  
+    <dt class="align-right bold"><span class="">name</span></dt>
+    <dd class="rounded-all"><p>Orded by the name of the member</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>Returns a list of profile objects encoded as JSON</p>
+  <dl>
+   
+    <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+    <dd class="rounded-all">
+    <p>Member bio. When profile does not belong to the authenticated member, this may be omitted if member opted to hide their bio from others</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="birthday"><span class="">birthday</span></dt>
+    <dd class="rounded-all">
+    <p>Returned only when the fields request parameter value includes 'birthday'
+and only for the authenticated member when defined</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="day"><span class="">day</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric day member was born. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="month"><span class="">month</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric month member was born. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="year"><span class="">year</span></dt>
+       <dd class="rounded-all">
+        <p>Year member was born</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country code associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="email"><span class="">email</span></dt>
+    <dd class="rounded-all">
+    <p>Member email address. Provided only if a profile belongs to the authenticated member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="gender"><span class="">gender</span></dt>
+    <dd class="rounded-all">
+    <p>Returned only when the fields request parameter value includes "gender"
+and only for the authenticated member.
+Value may be one of "female", "male", "none", or "other".
+This field may be absent where gender is not defined</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_profile"><span class="">group_profile</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup Group profile information.
+This field is only returned when profile is requested in group contexts</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+       <dd class="rounded-all">
+        <p>Array of answers to Group Profile questions</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="answer"><span class="">answer</span></dt>
+            <dd class="rounded-all"><p>Answer text</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+            <dt class="align-right bold" title="question_id"><span class="">question_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric question identifier</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>The time this member joined the Group, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>The group associated with this membership</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+            <dd class="rounded-all"><p>Group photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric group ID</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Who can join this group and how. One of "approval", "closed", or "open"</p></dd>
+            
+            <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+            <dd class="rounded-all"><p>Group primary photo</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+            <dd class="rounded-all"><p>Color combination used generate group duotone</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Status of the group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Urlname used to identify the group on meetup.com</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="intro"><span class="">intro</span></dt>
+       <dd class="rounded-all">
+        <p>Member intro, may be omitted if member opted to hide their intro from other members</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="link"><span class="">link</span></dt>
+       <dd class="rounded-all">
+        <p>Member profile link, provides a link to the members chapter profile</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The leadership role of this member within the Group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Membership status in this Group.
+Value may be one of
+active, blocked, pending, pending_payment or none</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer defined title of member. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>The last time this member edited their Group profile, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+       <dd class="rounded-all">
+        <p>The last time this member visited the Group, represented as milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Unique numeric identifier for the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_pro_admin"><span class="">is_pro_admin</span></dt>
+    <dd class="rounded-all">
+    <p>Returns true if the member is an active admin of an active meetup pro network</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="joined"><span class="">joined</span></dt>
+    <dd class="rounded-all">
+    <p>Time member joined, represented as milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Geographic latitude associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of country associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Geographic longitude associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="messaging_pref"><span class="">messaging_pref</span></dt>
+    <dd class="rounded-all">
+    <p>The member's preference for being contacted from other members on the platform.
+Returned only when the fields request parameter value includes "messaging_pref".
+May be one of the following: "all_members", "groups_only", or "orgs_only"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Display name for the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="other_services"><span class="">other_services</span></dt>
+    <dd class="rounded-all">
+    <p>An object whose key's are the names of associated external
+networks and values are identities within those networks.
+The keys may be one of facebook, flickr, linkedin, tumblr or twitter.
+Returned only when "fields" request parameter value
+includes "other_services"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="identifier"><span class="">identifier</span></dt>
+       <dd class="rounded-all">
+        <p>A unique string identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="url"><span class="">url</span></dt>
+       <dd class="rounded-all">
+        <p>A url for this identity. May be the same as identifier in some cases</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+    <dd class="rounded-all">
+    <p>Member photo. May be absent if member has not chosen one.
+In group contexts, the Member's Group profile photo will be returned.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="privacy"><span class="">privacy</span></dt>
+    <dd class="rounded-all">
+    <p>Member's privacy preferences
+Returned only when the "fields" request parameter value includes "privacy"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="facebook"><span class="">facebook</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' of 'visible'.
+If absent, the member has not connected their Facebook account to Meetup</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible'</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Represents the authenticated member's relation to member.
+Returned when "fields" request parameter value includes "self" and
+the target member is not the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions available for the authenticated member to perform.
+Currently only "message" is supported</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="blocks"><span class="">blocks</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indication of whether or not the authenticated member blocks this member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="common"><span class="">common</span></dt>
+       <dd class="rounded-all">
+        <p>Information the authenticated member has in common with this member</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+            <dd class="rounded-all"><p>List of common groups</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="friends"><span class="">friends</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indication of whether or not the authenticated member is a friend of the member</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State associated with Member's location, where available</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>a string with one of the following values: {'active', 'prereg', 'unknown'}</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_find_groups.html
+++ b/test/data/_find_groups.html
@@ -1,0 +1,1302 @@
+
+        
+
+<div id="">
+  <h2>Find Groups</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /find/groups
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Text, location, category and friend-based group searches</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/find/groups">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>All parameters are optional. If you do not supply some explicit form of location, the results will be based on your registered Meetup profile location, falling back on your IP's geographic location.</p>
+<p>If we can't find find Meetup groups matching your criteria you may optionally request that a small set of suggestions are returned in their place.
+To do so, send a request parameter named <code>fallback_suggestions</code> set to <code>true</code>. You can infer that a list of Meetup groups return are fallback suggestions when
+the <code>X-Total-Count</code> pagination response header has a <code>0</code> value.</p>
+<p>See the 'filter' parameter for more information controlling the results returned. Ordering does not apply to friend-filtered queries.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="category"><span class="">category</span></dt>
+    <dd class="rounded-all"><p>Comma-delimited list of numeric category ids</p></dd>
+  
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all"><p>A valid two character country code, defaults to US</p></dd>
+  
+    <dt class="align-right bold" title="fallback_suggestions"><span class="">fallback_suggestions</span></dt>
+    <dd class="rounded-all"><p>boolean indicator of whether or not to return a list of curated suggestions for groups if we can't find groups matching your criteria</p></dd>
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>Request that additional fields (separated by commas) be included in the output.</p></dd>
+  
+    <dt class="align-right bold" title="filter"><span class="">filter</span></dt>
+    <dd class="rounded-all"><p>Determines which groups are returned. If 'all' (default), the text and category parameters are applied. If 'friends', groups your friends are in are returned. The value of this parameter may be one of all, friends</p></dd>
+  
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all"><p>Approximate latitude</p></dd>
+  
+    <dt class="align-right bold" title="location"><span class="">location</span></dt>
+    <dd class="rounded-all"><p>Raw text location query</p></dd>
+  
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all"><p>Approximate longitude</p></dd>
+  
+    <dt class="align-right bold" title="radius"><span class="">radius</span></dt>
+    <dd class="rounded-all"><p>Radius in miles. May be 0.0-100.0, 'global' or 'smart', a dynamic radius based on the number of active groups in the area. Defaults to member's preferred radius</p></dd>
+  
+    <dt class="align-right bold" title="self_groups"><span class="">self_groups</span></dt>
+    <dd class="rounded-all"><p>set to 'include' or 'exclude' Meetups the authorized member belongs to; default is 'include'</p></dd>
+  
+    <dt class="align-right bold" title="text"><span class="">text</span></dt>
+    <dd class="rounded-all"><p>Raw full text search query</p></dd>
+  
+    <dt class="align-right bold" title="topic_id"><span class="">topic_id</span></dt>
+    <dd class="rounded-all"><p>Comma-delimited list of numeric topic ids</p></dd>
+  
+    <dt class="align-right bold" title="upcoming_events"><span class="">upcoming_events</span></dt>
+    <dd class="rounded-all"><p>If true, filters text and category based searches on groups that have upcoming events. Defaults to false</p></dd>
+  
+    <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+    <dd class="rounded-all"><p>Zipcode of location to limit search to</p></dd>
+  
+  </dl>
+  
+  <h4 id="ordering">Ordering</h4>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold"><span class="">distance</span></dt>
+    <dd class="rounded-all"><p>Order by distance</p></dd>
+  
+    <dt class="align-right bold"><span class="">members</span></dt>
+    <dd class="rounded-all"><p>Order by number of members</p></dd>
+  
+    <dt class="align-right bold"><span class="">most_active</span></dt>
+    <dd class="rounded-all"><p>Order by group with most active members</p></dd>
+  
+    <dt class="align-right bold"><span class="">newest</span></dt>
+    <dd class="rounded-all"><p>Order by date group was founded</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="approved"><span class="">approved</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean indicator for whether this Group has been approved or not.
+New Groups are generally approved (or removed)
+soon after creation.
+Returned when the "fields" request parameter value includes
+"approved"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="category"><span class="">category</span></dt>
+    <dd class="rounded-all">
+    <p>The primary category of the group, if the group has one</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric category id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>String identifier of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name used for sorting</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city_link"><span class="">city_link</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, a URL for the group's city</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="contributions"><span class="">contributions</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field containing the contribution details of the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="enabled"><span class="">enabled</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean stating if contributions are enabled for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="potential"><span class="">potential</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean stating that potential contributions are enabled for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="reason"><span class="">reason</span></dt>
+       <dd class="rounded-all">
+        <p>The reason a member might consider contributing</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thanks"><span class="">thanks</span></dt>
+       <dd class="rounded-all">
+        <p>The 'thank you' message to be given when a contribution is made</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time the group was created in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>Short description of group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="discussion_preferences"><span class="">discussion_preferences</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field that contains preference and permission data for group discussions</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="draft_event_count"><span class="">draft_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of draft events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee_options"><span class="">fee_options</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, returns payment options for event ticketing</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currencies"><span class="">currencies</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable currencies for the payment method specified by type</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="code"><span class="">code</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="default"><span class="">default</span></dt>
+            <dd class="rounded-all"><p>A boolean set to true if the currency is the group's default currency, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="is_setup"><span class="">is_setup</span></dt>
+       <dd class="rounded-all">
+        <p>A boolean set to true if the payment method specified by 'type' is set up for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="setup_link"><span class="">setup_link</span></dt>
+       <dd class="rounded-all">
+        <p>The URL for setting up the payment method specified by 'type'. This is returned if the payment method specified by 'type' is not set up for the group and the member has the permission to set it up</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of Set(stripe, wepay, paypal, none, cash)</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Group photo</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric group ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_simplehtml"><span class="">is_simplehtml</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, 'true' when the group description has been saved in a simplified HTML format, 'false' otherwise.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_info"><span class="">join_info</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, lists any questions requested when joining and required fields</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="photo_req"><span class="">photo_req</span></dt>
+       <dd class="rounded-all">
+        <p>true if required, false otherwise</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="questions"><span class="">questions</span></dt>
+       <dd class="rounded-all">
+        <p>List of profile questions organizer would like new members to answer prior to joining</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the question</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>The text of the question</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="questions_req"><span class="">questions_req</span></dt>
+       <dd class="rounded-all">
+        <p>true if required, false otherwise</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+    <dd class="rounded-all">
+    <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Group primary photo</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+    <dd class="rounded-all">
+    <p>Lang of founder or coordinator</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="last_event"><span class="">last_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the last hosted event, if the group has one. Returned when the "fields" request parameter value contains "last_event"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Latitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="leader_limit"><span class="">leader_limit</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup leaders limit in group (4 leaders for the Basic Subscription), note this info available only for orgs and coorgs</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="leads"><span class="">leads</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the number of members on this group's leadership team. Returned when the "fields" request parameter value contains "leads"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to group on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="list_addr"><span class="">list_addr</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field returning list address prefix. List mail will be {list_addr}-list@meetup.com. Announce email will be {list_addr}-announce@meetup.com. You must be a member of the group to see this</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="list_mode"><span class="">list_mode</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the policy for who can post the group mailing list. Returned when the "fields" request parameter value contains "list_mode". Value may be one of "moderated", "off", "open", or "orgs_only"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+    <dd class="rounded-all">
+    <p>City/State or City/Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Longitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_cap"><span class="">member_cap</span></dt>
+    <dd class="rounded-all">
+    <p>Number representing the maximum number of active members this group can have if capped. Returned only when requested in the fields request parameter and the authenticated member has permission to approve members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_limit"><span class="">member_limit</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup members limit in group (now it's 50 members in the Basic Subscription)</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="members"><span class="">members</span></dt>
+    <dd class="rounded-all">
+    <p>Number of Meetup members in this group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, returns membership dues for group if any</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+       <dd class="rounded-all">
+        <p>Currency in which the fee is declared</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="dues_links"><span class="">dues_links</span></dt>
+       <dd class="rounded-all">
+        <p>Links to dues management and checkout pages.</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="checkout_url"><span class="">checkout_url</span></dt>
+            <dd class="rounded-all"><p>Dues checkout page URL</p></dd>
+            
+            <dt class="align-right bold" title="settings_url"><span class="">settings_url</span></dt>
+            <dd class="rounded-all"><p>(Organizers only) Dues settings page URL</p></dd>
+            
+            <dt class="align-right bold" title="start_url"><span class="">start_url</span></dt>
+            <dd class="rounded-all"><p>(Organizers only) Dues setup page URL</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric fee value</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee_desc"><span class="">fee_desc</span></dt>
+       <dd class="rounded-all">
+        <p>The interval at which dues must be paid. Possible values may include: "month", "year", "day", or "every other day"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="methods"><span class="">methods</span></dt>
+       <dd class="rounded-all">
+        <p>Methods of payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="amazon_payments"><span class="">amazon_payments</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Amazon Payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="credit_card"><span class="">credit_card</span></dt>
+            <dd class="rounded-all"><p>(Deprecated - use <code>wepay</code> or <code>stripe</code> instead) Boolean indicator that credit cards are accepted</p></dd>
+            
+            <dt class="align-right bold" title="other"><span class="">other</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that other forms of payment are accepted</p></dd>
+            
+            <dt class="align-right bold" title="paypal"><span class="">paypal</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Paypal payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="stripe"><span class="">stripe</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Stripe payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="wepay"><span class="">wepay</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Wepay payments are accepted</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="reasons"><span class="">reasons</span></dt>
+       <dd class="rounded-all">
+        <p>Array of reasons containing one or more of the following values compensate_organizer, cover_costs, encourage_engagement, improve_meetups, other, provide_supplies, reserve_fund</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="reasons_other"><span class="">reasons_other</span></dt>
+       <dd class="rounded-all">
+        <p>An additional reason if specified.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+       <dd class="rounded-all">
+        <p>Conditions for refunds</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="custom"><span class="">custom</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator of a custom refund policy</p></dd>
+            
+            <dt class="align-right bold" title="group_closes"><span class="">group_closes</span></dt>
+            <dd class="rounded-all"><p>refund applies when the group closes</p></dd>
+            
+            <dt class="align-right bold" title="member_banned"><span class="">member_banned</span></dt>
+            <dd class="rounded-all"><p>refund applies when the member is banned</p></dd>
+            
+            <dt class="align-right bold" title="member_leaves"><span class="">member_leaves</span></dt>
+            <dd class="rounded-all"><p>refund applies when member leaves the group</p></dd>
+            
+            <dt class="align-right bold" title="none"><span class="">none</span></dt>
+            <dd class="rounded-all"><p>indicates there is no refund policy</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="required"><span class="">required</span></dt>
+       <dd class="rounded-all">
+        <p>true if dues are required</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="required_to"><span class="">required_to</span></dt>
+       <dd class="rounded-all">
+        <p>If the dues are required this indicates what they are required for. Currently may only be 'join'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self_payment_required"><span class="">self_payment_required</span></dt>
+       <dd class="rounded-all">
+        <p>Returns true if the authorized user is prevented from participating in the group until a payment is made</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="trial_days"><span class="">trial_days</span></dt>
+       <dd class="rounded-all">
+        <p>When present, returns the number of days the group is offering a free trial period for to new members. When not present, this indicates that the group does not offer a trial membership period</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="meta_category"><span class="">meta_category</span></dt>
+    <dd class="rounded-all">
+    <p>The meta category of the group, if the group has one</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="best_topics"><span class="">best_topics</span></dt>
+       <dd class="rounded-all">
+        <p>Represents the best topic matches for this category, returned when the "fields"
+request parameter value includes "best_topics"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic id</p></dd>
+            
+            <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+            <dd class="rounded-all"><p>Language topic originates from</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic</p></dd>
+            
+            <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+            <dd class="rounded-all"><p>The unique keyword used to identify this topic</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="category_ids"><span class="">category_ids</span></dt>
+       <dd class="rounded-all">
+        <p>List of numeric category ids associated with this topic category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic-category id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic-category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Photo representing this category</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>Unique string identifier for this category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name used for sorting</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="next_event"><span class="">next_event</span></dt>
+    <dd class="rounded-all">
+    <p>The current ongoing or next upcoming event, if one is scheduled</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="nominated_member"><span class="">nominated_member</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns if the logged in member has been nominated to take over the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="organizer"><span class="">organizer</span></dt>
+    <dd class="rounded-all">
+    <p>Group's primary organizer</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Bio of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer photo, where defined</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="past_event_count"><span class="">past_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of past events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="pending_members"><span class="">pending_members</span></dt>
+    <dd class="rounded-all">
+    <p>Number representing the count of members pending organizer approval to join. Returned only when requested in the fields request parameter and the authenticated member has permission to approve members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+    <dd class="rounded-all">
+    <p>Color combination used generate group duotone</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+       <dd class="rounded-all">
+        <p>Composite color in hexidecimal format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+       <dd class="rounded-all">
+        <p>Dark color in hexidecimal format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+       <dd class="rounded-all">
+        <p>Light color in hexidecimal format</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photos"><span class="">photos</span></dt>
+    <dd class="rounded-all">
+    <p>A small set of photos from the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_description"><span class="">plain_text_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in plain text format. Returned when then "fields" request parameter value contains "plain_text_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_no_images_description"><span class="">plain_text_no_images_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in plain text format with no images. Returned when then "fields" request parameter value contains "plain_text_no_images_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="proposed_event_count"><span class="">proposed_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of proposed events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="score"><span class="">score</span></dt>
+    <dd class="rounded-all">
+    <p>A numeric value representing how the relevancy of the group in this search context</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, contains details specific to the authorized user in this Meetup Group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform, potentially "broadcast_message": the ability to broadcast messages to group members via the "announce" mailing list, "event_create": the ability to create new events, "event_draft": the ability to save new events as drafts, "role_assign": the ability to assign member roles, "edit": the ability to edit group settings, "member_approval": the ability to approve or decline member requests to join, or "subscription_upgrade": the ability to upgrade this group's subscription plan</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Member's membership dues if the group has membership dues</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="cancelled"><span class="">cancelled</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that membership dues were cancelled</p></dd>
+            
+            <dt class="align-right bold" title="exempt"><span class="">exempt</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that the member is exempt from payment.</p></dd>
+            
+            <dt class="align-right bold" title="paid_until"><span class="">paid_until</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns the time in milliseconds since the epoch that the member's next payment is due</p></dd>
+            
+            <dt class="align-right bold" title="period_status"><span class="">period_status</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns one of the following values grace paid pending unpaid</p></dd>
+            
+            <dt class="align-right bold" title="total_amount"><span class="">total_amount</span></dt>
+            <dd class="rounded-all"><p>Total amount paid</p></dd>
+            
+            <dt class="align-right bold" title="transaction_time"><span class="">transaction_time</span></dt>
+            <dd class="rounded-all"><p>Time the transaction was made in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="trial"><span class="">trial</span></dt>
+            <dd class="rounded-all"><p>If the group offers a trial membership, this indicates information for unpaid members.</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="previous_membership_dues"><span class="">previous_membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Member's membership dues history when currently not a part of group i.e Status=none if the group has membership dues</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="cancelled"><span class="">cancelled</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that membership dues were cancelled</p></dd>
+            
+            <dt class="align-right bold" title="exempt"><span class="">exempt</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that the member is exempt from payment.</p></dd>
+            
+            <dt class="align-right bold" title="paid_until"><span class="">paid_until</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns the time in milliseconds since the epoch that the member's next payment is due</p></dd>
+            
+            <dt class="align-right bold" title="period_status"><span class="">period_status</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns one of the following values grace paid pending unpaid</p></dd>
+            
+            <dt class="align-right bold" title="total_amount"><span class="">total_amount</span></dt>
+            <dd class="rounded-all"><p>Total amount paid</p></dd>
+            
+            <dt class="align-right bold" title="transaction_time"><span class="">transaction_time</span></dt>
+            <dd class="rounded-all"><p>Time the transaction was made in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="trial"><span class="">trial</span></dt>
+            <dd class="rounded-all"><p>If the group offers a trial membership, this indicates information for unpaid members.</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>Member's role in group, if any: Organizer, Assistant Organizer, Event Organizer, etc.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Indicates the authorized user's membership with this group. Value may be one of "none", "pending", "pending_payment", "active", or "blocked"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+       <dd class="rounded-all">
+        <p>Member's last visit to the group site, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, a shorted URL for the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="similar_groups"><span class="">similar_groups</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns up to 5 groups similar to this groups, best suited for the authenticated member when a single group is queried for. Note: this field is being deprecated in favor of making a separate request to /:urlname/similar_groups</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Id of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photos"><span class="">photos</span></dt>
+       <dd class="rounded-all">
+        <p>Optional fields parameter. A small set of photos from the group</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What this group calls it's members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="simple_html_description"><span class="">simple_html_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in simple HTML source format. If this group's description was saved in simple HTML format, the description field will be an HTML translation of this source. Returned when the "fields" request parameter value contains "simple_html_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State of the group, if in US or Canada</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>Status of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+    <dd class="rounded-all">
+    <p>This represents the universal timezone identifier for the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the group's topics</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+       <dd class="rounded-all">
+        <p>Language topic originates from</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+       <dd class="rounded-all">
+        <p>The unique keyword used to identify this topic</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="untranslated_city"><span class="">untranslated_city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group, not translated</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="upcoming_event_count"><span class="">upcoming_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of upcoming events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+    <dd class="rounded-all">
+    <p>Urlname used to identify the group on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Who can see this group. One of members, public or public_limited</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="welcome_message"><span class="">welcome_message</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the Group's default welcome message if the authenticated member is the organizer of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="who"><span class="">who</span></dt>
+    <dd class="rounded-all">
+    <p>What the group calls its members</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_find_locations.html
+++ b/test/data/_find_locations.html
@@ -1,0 +1,127 @@
+
+        
+
+<div id="">
+  <h2>Find locations</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /find/locations
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Provides a query interface for finding known locations</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/find/locations">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>This endpoint uses HTTP <a href="/meetup_api/docs/#v3_json">Link header based pagination</a>.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all"><p>Search for locations based on location latitude.
+Must be provided with "lon"</p></dd>
+  
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all"><p>Search for locations based on location longitude.
+Must be provided with "lat"</p></dd>
+  
+    <dt class="align-right bold" title="offset"><span class="">offset</span></dt>
+    <dd class="rounded-all"><p>The current offset in the paginated set, represented as an incrementing value</p></dd>
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>The desired number of locations to return in a single set of results.
+Defaults to 200</p></dd>
+  
+    <dt class="align-right bold" title="query"><span class="">query</span></dt>
+    <dd class="rounded-all"><p>Search for locations based on city name or zip code</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>The order the results are returned in is based on the request parameters provided.
+By default, the nearest results based on "lat" and
+"lon" provided will be returned first,
+otherwise location with the highest member density will be returned first.</p>
+  <dl>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>Name of city</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Two character country code</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Approximate location latitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Localized name of country based on request's language information</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Approximate location longitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name_string"><span class="">name_string</span></dt>
+    <dd class="rounded-all">
+    <p>The full name of the location as preformatted string</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>Enclosing location state, if the location's country declares one</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+    <dd class="rounded-all">
+    <p>The location's zip code. For locations in countries without zip codes, a placeholder will be returned</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_find_topic_categories.html
+++ b/test/data/_find_topic_categories.html
@@ -1,0 +1,184 @@
+
+        
+
+<div id="">
+  <h2>Topic Categories</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /find/topic_categories
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Returns a list high level topic categories</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/find/topic_categories">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>No parameters are required. Authenticated members may request "best_topics"
+using the "fields" request parameter. By default these topics will selected
+based on groups in the member's location. Alternatively you may supply a "lat",
+"lon", and "radius" to center these topic suggestions</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-limited list of optional fields to append to the response</p></dd>
+  
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all"><p>An optional approximate latitude to center a request for "best_topics". When not provided, lat associated with member is used</p></dd>
+  
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all"><p>An optional approximate longitude to center a request for "best_topics". When not provided, lon associated with member is used</p></dd>
+  
+    <dt class="align-right bold" title="radius"><span class="">radius</span></dt>
+    <dd class="rounded-all"><p>An radius (in miles) to center a request for "best_topics". When not provided, the members default alert radius is used</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>Returns a list of topic category objects</p>
+  <dl>
+   
+    <dt class="align-right bold" title="best_topics"><span class="">best_topics</span></dt>
+    <dd class="rounded-all">
+    <p>Represents the best topic matches for this category, returned when the "fields"
+request parameter value includes "best_topics"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+       <dd class="rounded-all">
+        <p>Language topic originates from</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+       <dd class="rounded-all">
+        <p>The unique keyword used to identify this topic</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="category_ids"><span class="">category_ids</span></dt>
+    <dd class="rounded-all">
+    <p>List of numeric category ids associated with this topic category</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric topic-category id</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Display name of the topic-category</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+    <dd class="rounded-all">
+    <p>Photo representing this category</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+    <dd class="rounded-all">
+    <p>Unique string identifier for this category</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name used for sorting</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_find_topics.html
+++ b/test/data/_find_topics.html
@@ -1,0 +1,106 @@
+
+        
+
+<div id="">
+  <h2>Find Topics</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /find/topics
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Find topics by name</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/find/topics">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>This endpoint uses HTTP <a href="/meetup_api/docs/#v3_json">Link header based pagination</a>.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>Number of results to return in a single set of results</p></dd>
+  
+    <dt class="align-right bold" title="query"><span class="param_required">query</span></dt>
+    <dd class="rounded-all"><p>The text to topic text search for</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>Returns an array of Topics</p>
+  <dl>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>The description of the topic</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_count"><span class="">group_count</span></dt>
+    <dd class="rounded-all">
+    <p>The number of groups using this topic</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric topic id</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+    <dd class="rounded-all">
+    <p>Language topic originates from</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_count"><span class="">member_count</span></dt>
+    <dd class="rounded-all">
+    <p>The number of members interested in this topic</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Display name of the topic</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+    <dd class="rounded-all">
+    <p>The unique keyword used to identify this topic</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_find_upcoming_events.html
+++ b/test/data/_find_upcoming_events.html
@@ -1,0 +1,833 @@
+
+        
+
+<div id="">
+  <h2>Find Upcoming Events</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /find/upcoming_events
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Returns a list of upcoming events</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/find/upcoming_events">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>By default, the events returned will be based on the hosting groups near the authenticated member's location.
+To customize this location, send a valid "lat" and "lon" parameter combination reflecting a desired location.</p>
+<p>You may filter results using an topic category identifier from the <a href="/meetup_api/docs/find/topic_categories/">Topic Categories API</a></p>
+<p>You may specify 'fields' to expand response events with corresponded fields</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="end_date_range"><span class="">end_date_range</span></dt>
+    <dd class="rounded-all"><p>Return events that start before this date. The date must follow this format: YYYY-MM-DDTHH:MM:SS.</p></dd>
+  
+    <dt class="align-right bold" title="end_time_range"><span class="">end_time_range</span></dt>
+    <dd class="rounded-all"><p>Return events that start before this time. The time must follow this format: HH:MM:SS. The time is exlusive. A start_time_range must also be present</p></dd>
+  
+    <dt class="align-right bold" title="excluded_groups"><span class="">excluded_groups</span></dt>
+    <dd class="rounded-all"><p>IDs for groups to exclude from the returned events. excluded_groups overrides the include and only
+values for self_groups. In other words, if excluded_groups is nonempty,
+then groups specified in excluded_groups will be excluded
+even if they are in the set of groups the authenticated member belongs to.</p></dd>
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional fields to populate in the response</p></dd>
+  
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all"><p>Approximate target latitude</p></dd>
+  
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all"><p>Approximate target longitude</p></dd>
+  
+    <dt class="align-right bold" title="order"><span class="">order</span></dt>
+    <dd class="rounded-all"><p>The sort order of returned events.
+Valid values include: 'best' and 'time'.
+'best' orders events by recommendation score, while 'time' orders events by the by the event's start time in increasing order.
+Defaults to 'best'.</p></dd>
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>A target minimum number of events to return in a single page of results. The number returned is non-deterministic but a best-effort attempt will be made to return at least some. Defaults to 32</p></dd>
+  
+    <dt class="align-right bold" title="radius"><span class="">radius</span></dt>
+    <dd class="rounded-all"><p>Radius in miles. May be 0.0-100.0, 'global' or 'smart', a dynamic radius based on the number of active groups in the area. Defaults to member's preferred radius</p></dd>
+  
+    <dt class="align-right bold" title="self_groups"><span class="">self_groups</span></dt>
+    <dd class="rounded-all"><p>set to 'include' or 'exclude' or 'only' get groups that the member belongs to. Defaults to 'include.'
+When self_groups is set to only and the order is set to time, the following fields are disregarded: page, end_date_range, lat and lon.</p></dd>
+  
+    <dt class="align-right bold" title="start_date_range"><span class="">start_date_range</span></dt>
+    <dd class="rounded-all"><p>Return events that start after this date. The date must follow this format: YYYY-MM-DDTHH:MM:SS.
+It defaults to the current date and time.</p></dd>
+  
+    <dt class="align-right bold" title="start_time_range"><span class="">start_time_range</span></dt>
+    <dd class="rounded-all"><p>Return events that start after this time. The time must follow this format: HH:MM:SS. The time is inclusive. An end_time_range must also be present.</p></dd>
+  
+    <dt class="align-right bold" title="text"><span class="">text</span></dt>
+    <dd class="rounded-all"><p>Full text search query</p></dd>
+  
+    <dt class="align-right bold" title="topic_category"><span class="">topic_category</span></dt>
+    <dd class="rounded-all"><p>Numeric topic category identifier for filtering recommendations by a topic category</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>Returns a list of event objects and the resolved city</p>
+  <dl>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>The current city in context</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="city"><span class="">city</span></dt>
+       <dd class="rounded-all">
+        <p>The name of the city</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>The ISO_3166-1 country code for the country which contains the city</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric identifier of the city</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>The latitude of the city</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>The longitude of the city</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="member_count"><span class="">member_count</span></dt>
+       <dd class="rounded-all">
+        <p>The number of Meetup members in the city</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name_string"><span class="">name_string</span></dt>
+       <dd class="rounded-all">
+        <p>The full name of the city, as returned by query search, if applicable</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>The state which contains the city, if applicable</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+       <dd class="rounded-all">
+        <p>The zip code of the city. For cities in countries without ZIP codes, a placeholder will be returned</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="events"><span class="">events</span></dt>
+    <dd class="rounded-all">
+    <p>List of events</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="attendance_count"><span class="">attendance_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of all members marked as attended, yes RSVPs that were not changed by attendance and their guests</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="attendance_sample"><span class="">attendance_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection of members marked as attended and yes RSVPs that were not changed by attendance</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="attendee_sample"><span class="">attendee_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection of attendance records of members marked as attended and yes RSVPs that were not changed by attendance. For upcoming events, this represents collection of yes RSVPs</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="comment_count"><span class="">comment_count</span></dt>
+       <dd class="rounded-all">
+        <p>An aggregate count of all comments and replies for a given event, returned when fields request parameter value includes 'comment_count'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+       <dd class="rounded-all">
+        <p>Is event date matches the series pattern</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="description"><span class="">description</span></dt>
+       <dd class="rounded-all">
+        <p>Description of the event in HTML. Email addresses and phone numbers will be masked for non-members</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="description_images"><span class="">description_images</span></dt>
+       <dd class="rounded-all">
+        <p>A list of image urls included in the event description.  returned when "fields" request parameter value contains "description_images, only supported for GET /event/:id currently"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+       <dd class="rounded-all">
+        <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_hosts"><span class="">event_hosts</span></dt>
+       <dd class="rounded-all">
+        <p>List of members hosting the event, returned when fields request parameter value includes 'event_hosts'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host_count"><span class="">host_count</span></dt>
+            <dd class="rounded-all"><p>Number of times member hosted for group</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Host member's id</p></dd>
+            
+            <dt class="align-right bold" title="intro"><span class="">intro</span></dt>
+            <dd class="rounded-all"><p>Host member's introduction</p></dd>
+            
+            <dt class="align-right bold" title="join_date"><span class="">join_date</span></dt>
+            <dd class="rounded-all"><p>Group join date in milliseconds since epoch</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Host member's name</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Member photo if one exists</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="featured"><span class="">featured</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indicator of whether or not a given event is featured, returned when fields request parameter value includes 'featured'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="featured_photo"><span class="">featured_photo</span></dt>
+       <dd class="rounded-all">
+        <p>A featured photo for this event, returned when the 'fields' request paramater includes 'featured_photo'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Ticketing fee information for events that support payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+            <dd class="rounded-all"><p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p></dd>
+            
+            <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+            <dd class="rounded-all"><p>Amount of the fee</p></dd>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Fee description, typically "per-person"</p></dd>
+            
+            <dt class="align-right bold" title="label"><span class="">label</span></dt>
+            <dd class="rounded-all"><p>Label for fee, typically "Price"</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>Boolean flag indicating if this fee is required to RSVP</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="fee_options"><span class="">fee_options</span></dt>
+       <dd class="rounded-all">
+        <p>Payment options for event ticketing, returned when the 'fields' request parameter value includes 'fee_options'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="currencies"><span class="">currencies</span></dt>
+            <dd class="rounded-all"><p>Acceptable currencies for the payment method specified by type</p></dd>
+            
+            <dt class="align-right bold" title="is_setup"><span class="">is_setup</span></dt>
+            <dd class="rounded-all"><p>A boolean set to true if the payment method specified by 'type' is set up for the group</p></dd>
+            
+            <dt class="align-right bold" title="setup_link"><span class="">setup_link</span></dt>
+            <dd class="rounded-all"><p>The URL for setting up the payment method specified by 'type'. This is returned if the payment method specified by 'type' is not set up for the group and the member has the permission to set it up</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Acceptable methods of payments may be one of Set(stripe, wepay, paypal, none, cash)</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>Information about group hosting the event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="category"><span class="">category</span></dt>
+            <dd class="rounded-all"><p>Category group belongs to, returned when fields request parameter value includes 'group_category'</p></dd>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="join_info"><span class="">join_info</span></dt>
+            <dd class="rounded-all"><p>Lists any questions requested when joining and required fields. Returned with "fields" request parameter value includes "group_join_info"</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p></dd>
+            
+            <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+            <dd class="rounded-all"><p>Group primary photo, returned when fields request parameter value includes 'group_key_photo'</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate group latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate group longitude</p></dd>
+            
+            <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+            <dd class="rounded-all"><p>Membership dues information associated with hosting group, returned when fields request parameter value includes 'group_membership_dues'</p></dd>
+            
+            <dt class="align-right bold" title="meta_category"><span class="">meta_category</span></dt>
+            <dd class="rounded-all"><p>The meta category of the group, if the group has one, returned when fields request parameter value inclues 'meta_category'</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="past_event_count"><span class="">past_event_count</span></dt>
+            <dd class="rounded-all"><p>The number of past events belonging to the group, returned when "fields" includes "group_past_event_count"</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Photo associated with group, returned when fields request parameter value includes 'group_photo'</p></dd>
+            
+            <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+            <dd class="rounded-all"><p>Color combination used to generate group duotone, returned when fields request parameter value includes 'group_photo_gradient'</p></dd>
+            
+            <dt class="align-right bold" title="pro_network"><span class="">pro_network</span></dt>
+            <dd class="rounded-all"><p>Information on group's Pro organization, returned when "fields" request parameter value includes "group_pro_network"</p></dd>
+            
+            <dt class="align-right bold" title="region"><span class="">region</span></dt>
+            <dd class="rounded-all"><p>Language and region of the group</p></dd>
+            
+            <dt class="align-right bold" title="self"><span class="">self</span></dt>
+            <dd class="rounded-all"><p>Information pertaining to the authenticated member with respect to the group, returned when fields request parameter value includes 'group_self_profile', 'group_self_actions', 'group_self_membership_dues', or 'group_self_status'</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of the group</p></dd>
+            
+            <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+            <dd class="rounded-all"><p>Timezone of group</p></dd>
+            
+            <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+            <dd class="rounded-all"><p>Topics related to the group, returned when fields request parameter value includes 'group_topics'</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric urlname identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+            <dd class="rounded-all"><p>Group visibility, returned when fields request parameter value includes 'group_visibility'. Value may be "public", "public_limited", or "members".</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="how_to_find_us"><span class="">how_to_find_us</span></dt>
+       <dd class="rounded-all">
+        <p>Additional information on how to find members at a venue when provided by an organizer, returned when fields request parameter value includes 'how_to_find_us'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>A unique alphanumeric identifier for event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+       <dd class="rounded-all">
+        <p>Is event happening online</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="link"><span class="">link</span></dt>
+       <dd class="rounded-all">
+        <p>Link to event on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+       <dd class="rounded-all">
+        <p>The local date of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+       <dd class="rounded-all">
+        <p>The local time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="manual_attendance_count"><span class="">manual_attendance_count</span></dt>
+       <dd class="rounded-all">
+        <p>Manually entered total attendee headcount, if any exists</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+       <dd class="rounded-all">
+        <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+       <dd class="rounded-all">
+        <p>Information about photo uploads for this event, returned when fields request parameter value includes 'photo_album'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="event"><span class="">event</span></dt>
+            <dd class="rounded-all"><p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for photo album</p></dd>
+            
+            <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+            <dd class="rounded-all"><p>Number of photos uploaded</p></dd>
+            
+            <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+            <dd class="rounded-all"><p>A small collection of photos uploaded for this event</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Album title</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="plain_text_description"><span class="">plain_text_description</span></dt>
+       <dd class="rounded-all">
+        <p>Plain text version of the event description. Email addresses and photo numbers will be masked for non-members. Returned when "fields" request parameter value contains "plain_text_description"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="plain_text_no_images_description"><span class="">plain_text_no_images_description</span></dt>
+       <dd class="rounded-all">
+        <p>Plain text version of the event description without images. Email addresses and photo numbers will be masked for non-members. Returned when "fields" request parameter value contains "plain_text_no_images_description"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+       <dd class="rounded-all">
+        <p>The number of "yes" RSVPS an event has capacity for</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_rules"><span class="">rsvp_rules</span></dt>
+       <dd class="rounded-all">
+        <p>Information about conditions that allow for member RSVPs, returned when fields request parameter value include 'rsvp_rules'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="close_time"><span class="">close_time</span></dt>
+            <dd class="rounded-all"><p>UTC time that RSVPs will no longer be accepted, though organizers may close RSVPs earlier</p></dd>
+            
+            <dt class="align-right bold" title="closed"><span class="">closed</span></dt>
+            <dd class="rounded-all"><p>Boolean value indicating whether or not RSVPing was explicitly closed for the event.</p></dd>
+            
+            <dt class="align-right bold" title="guest_limit"><span class="">guest_limit</span></dt>
+            <dd class="rounded-all"><p>Number of guests members may include in their RSVP, 0 or more</p></dd>
+            
+            <dt class="align-right bold" title="open_time"><span class="">open_time</span></dt>
+            <dd class="rounded-all"><p>UTC time that members may begin to RSVP</p></dd>
+            
+            <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+            <dd class="rounded-all"><p>The organizer-defined terms for refunds. If this is defined, you must provide the authenticated member a way to access this information before they can RSVP. They will need to agree to these terms before they RSVP</p></dd>
+            
+            <dt class="align-right bold" title="waitlisting"><span class="">waitlisting</span></dt>
+            <dd class="rounded-all"><p>Wait list handling when RSVP limit is reached. Value may be one of 'auto', 'manual' or 'off'</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection RSVPs for members attending this event, returned when fields request parameter value includes 'rsvp_sample'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>Creation time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p></dd>
+            
+            <dt class="align-right bold" title="member"><span class="">member</span></dt>
+            <dd class="rounded-all"><p>Member who RSVP'd</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>Last modified time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="rsvpable"><span class="">rsvpable</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean value indicating whether or not the authenticated member can RSVP or join the waitlist when the event is full.
+Returned when the "fields" request parameter value
+includes "rsvpable"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvpable_after_join"><span class="">rsvpable_after_join</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean value indicating whether or not the authenticated member can RSVP
+after joining the hosting group.
+Returned when the "fields" request parameter
+includes "rsvpable_after_join"
+and the authenticated member is <em>not</em> a member of the
+group hosting this event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="saved"><span class="">saved</span></dt>
+       <dd class="rounded-all">
+        <p>Whether the authorized member has saved the event, returned when fields request parameter value includes 'saved'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self"><span class="">self</span></dt>
+       <dd class="rounded-all">
+        <p>represents details particular to the authorized user, only present if requested and authenticated member is a member of the hosting group, returned when fields request parameter value includes 'self'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+            <dd class="rounded-all"><p>List of actions the authenticated member may perform, potentially one or more of the following</p>
+<p>"announce" to announce the event to the group's members</p>
+<p>"attendance" to view or take attendance for the event</p>
+<p>"copy" the ability to copy an event</p>
+<p>"comment" the ability to post a comment or reply</p>
+<p>"payments" the ability to mark members as paid if the event is ticketed</p>
+<p>"publish" to publish a draft event</p>
+<p>"edit" to edit the event information</p>
+<p>"edit_hosts" to edit the hosts for the event</p>
+<p>"email_attendees" the ability to email event attendees</p>
+<p>"delete" to delete the event</p>
+<p>"rsvp" to RSVP yes or no to the event</p>
+<p>"wait" to get on the waiting list (using the same RSVP methods).</p>
+<p>"dues" if an organizer requires membership dues to RSVP and the authorized
+ member has not paid theirs</p>
+<p>"upload_photo" the ability to upload a photo for the event</p>
+<p>"cancel" the ability to cancel the event</p>
+<p>"close" the ability to close the RSVPs for the event</p>
+<p>"open" the ability to open the RSVPs for the event</p>
+<p>"invite" the ability to invite someone for the event</p>
+<p>"download_attendees" the ability to download the attendees list for the event</p>
+<p>"take_attendance" the ability to take attendance for the event</p>
+<p>"delete_cancelled" the ability to delete the event if it is cancelled</p></dd>
+            
+            <dt class="align-right bold" title="pay_status"><span class="">pay_status</span></dt>
+            <dd class="rounded-all"><p>The authenticated member's payment status. This may be one of 'none', 'paid', 'partially_paid', 'payment_pending', 'echeck_pending', 'refund_pending', 'partially_refunded', 'refunded'</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The authenticated member's role in within the group, if any. This may be one of: Organizer, Assistant Organizer, Event Organizer, etc.</p></dd>
+            
+            <dt class="align-right bold" title="rsvp"><span class="">rsvp</span></dt>
+            <dd class="rounded-all"><p>Member's RSVP, if any</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="series"><span class="">series</span></dt>
+       <dd class="rounded-all">
+        <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Human displayable description of how often events in this series occur</p></dd>
+            
+            <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series ends/ended, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the series</p></dd>
+            
+            <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a monthly recurring series of events</p></dd>
+            
+            <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series begins/began, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the template event of the series</p></dd>
+            
+            <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a weekly recurring series of events</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+       <dd class="rounded-all">
+        <p>A shortened link for the event on meetup.com, returned when fields request parameter value includes "short_link"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="simple_html_description"><span class="">simple_html_description</span></dt>
+       <dd class="rounded-all">
+        <p>Description of the event, in simple HTML source format. If this event's description was saved in simple HTML format, the description field will be an HTML translation of this source. Returned when the "fields"' request parameter contains "simple_html_description"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>"cancelled", "upcoming", "past", "proposed", "suggested", or "draft"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+       <dd class="rounded-all">
+        <p>List of organizer-defined survey questions intended to be asked of RSVPing members. Returned when the "fields"' request parameter contains "answers"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric question identifier</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time for the event in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+       <dd class="rounded-all">
+        <p>The event venue, present only if selected and not hidden by an organizer</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+            <dd class="rounded-all"><p>Line 1 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+            <dd class="rounded-all"><p>Line 2 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+            <dd class="rounded-all"><p>Line 3 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="city"><span class="">city</span></dt>
+            <dd class="rounded-all"><p>City of venue</p></dd>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country code of venue</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric venue id</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+            <dd class="rounded-all"><p>The localized name of the venue's country</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Venue name</p></dd>
+            
+            <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+            <dd class="rounded-all"><p>Phone number of venue</p></dd>
+            
+            <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+            <dd class="rounded-all"><p>true if the editor of the event altered the original venues pin location, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of venue where available</p></dd>
+            
+            <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+            <dd class="rounded-all"><p>ZIP code if, venue is in US or Canada</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="venue_visibility"><span class="">venue_visibility</span></dt>
+       <dd class="rounded-all">
+        <p>Represents who can see the venue with a potential value of "members" or "public", returned when fields request parameter value includes "venue_visibility" and the authenticated member is a member of the group hosting the event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+       <dd class="rounded-all">
+        <p>Event visibility: "public", "public_limited", or "members". Events in private groups that do not expose limited information are visible only to that group's members and should not be made public.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of members on the waitlist, if one exists</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="web_actions"><span class="">web_actions</span></dt>
+       <dd class="rounded-all">
+        <p>Set of "Invite" and google/yahoo/ical/outlook "Add to calendar" web actions</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="why"><span class="">why</span></dt>
+       <dd class="rounded-all">
+        <p>We should do this because...</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs including guests</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_members_:member_id.html
+++ b/test/data/_members_:member_id.html
@@ -1,0 +1,2407 @@
+
+        
+
+<div id="get">
+  <h2>Get Member Profile</h2>
+  <div id="geturi" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /members/:member_id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Gets Member Profiles.
+For Group Profiles, see <a href="/meetup_api/docs/:urlname/members/:member_id">this endpoint</a></p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/members/:member_id">Try it in the console</a></p>
+  <h3 id="getparams" class="rounded-all">Request Parameters</h3>
+  <div class="getparam-notes"><p>A valid path parameter for :member_id is required. A value of "self"
+may be used in place of a numeric identifier to represent the authenticated
+Member's id</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited string of optional response field names.
+This may include groups, privacy, and topics</p></dd>
+  
+  </dl>
+  
+  <h3 id="getresponse" class="rounded-all">Response</h3>
+  <p>Returns a single Member Profile object</p>
+  <dl>
+   
+    <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+    <dd class="rounded-all">
+    <p>Member bio. When profile does not belong to the authenticated member, this may be omitted if member opted to hide their bio from others</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="birthday"><span class="">birthday</span></dt>
+    <dd class="rounded-all">
+    <p>Returned only when the fields request parameter value includes 'birthday'
+and only for the authenticated member when defined</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="day"><span class="">day</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric day member was born. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="month"><span class="">month</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric month member was born. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="year"><span class="">year</span></dt>
+       <dd class="rounded-all">
+        <p>Year member was born</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country code associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="email"><span class="">email</span></dt>
+    <dd class="rounded-all">
+    <p>Member email address. Provided only if a profile belongs to the authenticated member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="gender"><span class="">gender</span></dt>
+    <dd class="rounded-all">
+    <p>Returned only when the fields request parameter value includes "gender"
+and only for the authenticated member.
+Value may be one of "female", "male", "none", or "other".
+This field may be absent where gender is not defined</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Unique numeric identifier for the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_pro_admin"><span class="">is_pro_admin</span></dt>
+    <dd class="rounded-all">
+    <p>Returns true if the member is an active admin of an active meetup pro network</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="joined"><span class="">joined</span></dt>
+    <dd class="rounded-all">
+    <p>Time member joined, represented as milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="last_event"><span class="">last_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the last RSVP'd Meetup this member attended within the last two weeks,
+where available. Returned when the "fields"
+request parameter value contains "last_event"
+only for the profile of the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+       <dd class="rounded-all">
+        <p>Is event date matches the series pattern</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+       <dd class="rounded-all">
+        <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Ticketing fee information for events that support payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+            <dd class="rounded-all"><p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p></dd>
+            
+            <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+            <dd class="rounded-all"><p>Amount of the fee</p></dd>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Fee description, typically "per-person"</p></dd>
+            
+            <dt class="align-right bold" title="label"><span class="">label</span></dt>
+            <dd class="rounded-all"><p>Label for fee, typically "Price"</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>Boolean flag indicating if this fee is required to RSVP</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>Group hosting the event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate group latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate group longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="region"><span class="">region</span></dt>
+            <dd class="rounded-all"><p>Language and region of the group</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of the group</p></dd>
+            
+            <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+            <dd class="rounded-all"><p>Timezone of group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric urlname identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>A unique alphanumeric identifier for event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+       <dd class="rounded-all">
+        <p>Is event happening online</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+       <dd class="rounded-all">
+        <p>The local date of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+       <dd class="rounded-all">
+        <p>The local time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+       <dd class="rounded-all">
+        <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+       <dd class="rounded-all">
+        <p>Information about photo uploads for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="event"><span class="">event</span></dt>
+            <dd class="rounded-all"><p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for photo album</p></dd>
+            
+            <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+            <dd class="rounded-all"><p>Number of photos uploaded</p></dd>
+            
+            <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+            <dd class="rounded-all"><p>A small collection of photos uploaded for this event</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Album title</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+       <dd class="rounded-all">
+        <p>The number of "yes" RSVPS an event has capacity for</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection RSVPs for members attending this event, returned when the "fields" request parameter value includes "rsvp_sample"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>Creation time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p></dd>
+            
+            <dt class="align-right bold" title="member"><span class="">member</span></dt>
+            <dd class="rounded-all"><p>Member who RSVP'd</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>Last modified time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="series"><span class="">series</span></dt>
+       <dd class="rounded-all">
+        <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Human displayable description of how often events in this series occur</p></dd>
+            
+            <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series ends/ended, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the series</p></dd>
+            
+            <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a monthly recurring series of events</p></dd>
+            
+            <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series begins/began, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the template event of the series</p></dd>
+            
+            <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a weekly recurring series of events</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+       <dd class="rounded-all">
+        <p>Contains a list of organizer-defined survey questions intended to be asked of RSVPing members.
+Returned when the "fields" request parameter
+contains "survey_questions"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric question identifier</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time for the event in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+       <dd class="rounded-all">
+        <p>The event venue, present only if selected and not hidden by an organizer</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+            <dd class="rounded-all"><p>Line 1 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+            <dd class="rounded-all"><p>Line 2 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+            <dd class="rounded-all"><p>Line 3 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="city"><span class="">city</span></dt>
+            <dd class="rounded-all"><p>City of venue</p></dd>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country code of venue</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric venue id</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+            <dd class="rounded-all"><p>The localized name of the venue's country</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Venue name</p></dd>
+            
+            <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+            <dd class="rounded-all"><p>Phone number of venue</p></dd>
+            
+            <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+            <dd class="rounded-all"><p>true if the editor of the event altered the original venues pin location, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of venue where available</p></dd>
+            
+            <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+            <dd class="rounded-all"><p>ZIP code if, venue is in US or Canada</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of members on the waitlist, if one exists</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs including guests</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Geographic latitude associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of country associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Geographic longitude associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="memberships"><span class="">memberships</span></dt>
+    <dd class="rounded-all">
+    <p>Group memberships affiliated with this member.
+Returned only when fields request parameter value includes "memberships".
+This list may be omitted if the member has opted to hide their groups from others.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="member"><span class="">member</span></dt>
+       <dd class="rounded-all">
+        <p>Memberships where member holds a basic membership</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>The time this member joined the Group, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="group"><span class="">group</span></dt>
+            <dd class="rounded-all"><p>The group associated with this membership</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the Group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Membership status in this Group.
+Value may be one of
+active, blocked, pending, pending_payment or none</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>The last time this member edited their Group profile, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+            <dd class="rounded-all"><p>The last time this member visited the Group, represented as milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="organizer"><span class="">organizer</span></dt>
+       <dd class="rounded-all">
+        <p>Memberships where member is on the group's lead team</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>The time this member joined the Group, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="group"><span class="">group</span></dt>
+            <dd class="rounded-all"><p>The group associated with this membership</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the Group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Membership status in this Group.
+Value may be one of
+active, blocked, pending, pending_payment or none</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>The last time this member edited their Group profile, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+            <dd class="rounded-all"><p>The last time this member visited the Group, represented as milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="messaging_pref"><span class="">messaging_pref</span></dt>
+    <dd class="rounded-all">
+    <p>The member's preference for being contacted from other members on the platform.
+Returned only when the fields request parameter value includes "messaging_pref".
+May be one of the following: "all_members", "groups_only", or "orgs_only"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Display name for the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="next_event"><span class="">next_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing either the current ongoing or next RSVP'd Meetup, where available.
+Returned when the "fields"
+request parameter value contains "next_event"
+only for the profile of the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+       <dd class="rounded-all">
+        <p>Is event date matches the series pattern</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+       <dd class="rounded-all">
+        <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Ticketing fee information for events that support payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+            <dd class="rounded-all"><p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p></dd>
+            
+            <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+            <dd class="rounded-all"><p>Amount of the fee</p></dd>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Fee description, typically "per-person"</p></dd>
+            
+            <dt class="align-right bold" title="label"><span class="">label</span></dt>
+            <dd class="rounded-all"><p>Label for fee, typically "Price"</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>Boolean flag indicating if this fee is required to RSVP</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>Group hosting the event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate group latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate group longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="region"><span class="">region</span></dt>
+            <dd class="rounded-all"><p>Language and region of the group</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of the group</p></dd>
+            
+            <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+            <dd class="rounded-all"><p>Timezone of group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric urlname identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>A unique alphanumeric identifier for event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+       <dd class="rounded-all">
+        <p>Is event happening online</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+       <dd class="rounded-all">
+        <p>The local date of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+       <dd class="rounded-all">
+        <p>The local time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+       <dd class="rounded-all">
+        <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+       <dd class="rounded-all">
+        <p>Information about photo uploads for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="event"><span class="">event</span></dt>
+            <dd class="rounded-all"><p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for photo album</p></dd>
+            
+            <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+            <dd class="rounded-all"><p>Number of photos uploaded</p></dd>
+            
+            <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+            <dd class="rounded-all"><p>A small collection of photos uploaded for this event</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Album title</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+       <dd class="rounded-all">
+        <p>The number of "yes" RSVPS an event has capacity for</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection RSVPs for members attending this event, returned when the "fields" request parameter value includes "rsvp_sample"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>Creation time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p></dd>
+            
+            <dt class="align-right bold" title="member"><span class="">member</span></dt>
+            <dd class="rounded-all"><p>Member who RSVP'd</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>Last modified time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="series"><span class="">series</span></dt>
+       <dd class="rounded-all">
+        <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Human displayable description of how often events in this series occur</p></dd>
+            
+            <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series ends/ended, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the series</p></dd>
+            
+            <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a monthly recurring series of events</p></dd>
+            
+            <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series begins/began, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the template event of the series</p></dd>
+            
+            <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a weekly recurring series of events</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+       <dd class="rounded-all">
+        <p>Contains a list of organizer-defined survey questions intended to be asked of RSVPing members.
+Returned when the "fields" request parameter
+contains "survey_questions"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric question identifier</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time for the event in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+       <dd class="rounded-all">
+        <p>The event venue, present only if selected and not hidden by an organizer</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+            <dd class="rounded-all"><p>Line 1 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+            <dd class="rounded-all"><p>Line 2 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+            <dd class="rounded-all"><p>Line 3 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="city"><span class="">city</span></dt>
+            <dd class="rounded-all"><p>City of venue</p></dd>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country code of venue</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric venue id</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+            <dd class="rounded-all"><p>The localized name of the venue's country</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Venue name</p></dd>
+            
+            <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+            <dd class="rounded-all"><p>Phone number of venue</p></dd>
+            
+            <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+            <dd class="rounded-all"><p>true if the editor of the event altered the original venues pin location, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of venue where available</p></dd>
+            
+            <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+            <dd class="rounded-all"><p>ZIP code if, venue is in US or Canada</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of members on the waitlist, if one exists</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs including guests</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="other_services"><span class="">other_services</span></dt>
+    <dd class="rounded-all">
+    <p>An object whose key's are the names of associated external
+networks and values are identities within those networks.
+The keys may be one of facebook, flickr, linkedin, tumblr or twitter.
+Returned only when "fields" request parameter value
+includes "other_services"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="identifier"><span class="">identifier</span></dt>
+       <dd class="rounded-all">
+        <p>A unique string identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="url"><span class="">url</span></dt>
+       <dd class="rounded-all">
+        <p>A url for this identity. May be the same as identifier in some cases</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+    <dd class="rounded-all">
+    <p>Member photo. May be absent if member has not chosen one.
+In group contexts, the Member's Group profile photo will be returned.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="privacy"><span class="">privacy</span></dt>
+    <dd class="rounded-all">
+    <p>Member's privacy preferences
+Returned only when the "fields" request parameter value includes "privacy"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="facebook"><span class="">facebook</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' of 'visible'.
+If absent, the member has not connected their Facebook account to Meetup</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible'</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Represents the authenticated member's relation to member.
+Returned when "fields" request parameter value includes "self" and
+the target member is not the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions available for the authenticated member to perform.
+Currently only "message" is supported</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="blocks"><span class="">blocks</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indication of whether or not the authenticated member blocks this member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="common"><span class="">common</span></dt>
+       <dd class="rounded-all">
+        <p>Information the authenticated member has in common with this member</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+            <dd class="rounded-all"><p>List of common groups</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="friends"><span class="">friends</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indication of whether or not the authenticated member is a friend of the member</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State associated with Member's location, where available</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="stats"><span class="">stats</span></dt>
+    <dd class="rounded-all">
+    <p>High level numeric member statistics
+Returned only when fields request parameter value includes 'stats'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+       <dd class="rounded-all">
+        <p>Number of Meetup Group memberships.
+May be 0 if member chose to hide their groups from others</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvps"><span class="">rsvps</span></dt>
+       <dd class="rounded-all">
+        <p>Number of RSVPs.
+May be 0 if member chose to hide their groups from others</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>Number of Meetup topics member is interested in.
+May be 0 if member chose to hide their topics from others</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>a string with one of the following values: {'active', 'prereg', 'unknown'}</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+    <dd class="rounded-all">
+    <p>List of Meetup topics Member has interest in.
+Returned only when fields request parameter value includes "topics".
+This list may be omitted when member has opted to hide the topics from others.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+       <dd class="rounded-all">
+        <p>Language topic originates from</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+       <dd class="rounded-all">
+        <p>The unique keyword used to identify this topic</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+  
+  </dl>
+  
+  
+  <h3 id="getexamples" class="rounded-all">Examples</h3>
+  <p>Fetch your own profile with all your groups</p>
+<pre><code>curl -H "Authorization: bearer {ACCESS_TOKEN}" \
+    "https://api.meetup.com/members/self?fields=groups"
+</code></pre>
+  
+</div>
+
+<div id="edit">
+  <h2>Member Profile Edit</h2>
+  <div id="edituri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">PATCH</strong> /members/:member_id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">profile_edit</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  
+  </div>
+  
+  <h3 id="editparams" class="rounded-all">Request Parameters</h3>
+  <div class="editparam-notes"><p>All parameters are optional.</p>
+<p>OAuth authenticated applications should
+request the <a href="/meetup_api/auth/#profile_edit_scope">profile_edit</a>
+permission scope</p>
+<p>Some Meetup group organizers may define a set of profile questions
+they'd like their members to answer. You can obtain that question
+list using the <a href="/meetup_api/docs/:urlname/#get">Get Group</a> by sending
+ a "fields" request parameter containing
+"join_info"</p>
+<p>The authenticated member may set their currently location by either supplying a valid
+"city_id" or a valid "lat", "lon", or "zip".
+You can resolve a coordinate-based "zip" by using the
+<a href="/meetup_api/docs/find/locations">Find locations</a> API</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="add_topics"><span class="">add_topics</span></dt>
+    <dd class="rounded-all"><p>Comma-delimited list of topic ids to add to members interest list</p></dd>
+  
+    <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+    <dd class="rounded-all"><p>Member bio of up to 250 characters</p></dd>
+  
+    <dt class="align-right bold" title="bio_privacy"><span class="">bio_privacy</span></dt>
+    <dd class="rounded-all"><p>Preference for hiding or showing member bio to others.
+Value may be one of "hidden" or "visible"</p></dd>
+  
+    <dt class="align-right bold" title="birthday"><span class="">birthday</span></dt>
+    <dd class="rounded-all"><p>Member's date or year of birth.
+May be specified in one of the following formats.
+yyyy, mmddyyy or alternatively -1, which indicates that birthday
+data should be cleared</p></dd>
+  
+    <dt class="align-right bold" title="city_id"><span class="">city_id</span></dt>
+    <dd class="rounded-all"><p>Valid Meetup city identifier that indicates the city in which the member resides</p></dd>
+  
+    <dt class="align-right bold" title="facebook_privacy"><span class="">facebook_privacy</span></dt>
+    <dd class="rounded-all"><p>Preference for hiding showing information member's facebook connection.
+Value may be one of "hidden" or "visible" or absent if facebook is not connected</p></dd>
+  
+    <dt class="align-right bold" title="gender"><span class="">gender</span></dt>
+    <dd class="rounded-all"><p>Member's gender.
+Value may be one of "female", "male", "none", or "other"</p></dd>
+  
+    <dt class="align-right bold" title="groups_privacy"><span class="">groups_privacy</span></dt>
+    <dd class="rounded-all"><p>Preference for hiding or showing group memberships to others.
+Value may be one of "hidden" or "visible"</p></dd>
+  
+    <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+    <dd class="rounded-all"><p>Member's language preference.
+Value may be one of "de-DE", "en-AU", "en-US", "es", "es-ES", "fr-FR", "it-IT", "ja-JP", "ko-KR", "nl-NL", "pl-PL", "pt-BR", "ru-RU", "sv-SE", "th-TH", or "tr-TR"</p></dd>
+  
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all"><p>A valid latitude to resolve the closest location to associate with the member.
+This parameter must be accompanied by "lon" and "zip"</p></dd>
+  
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all"><p>A valid longitude to resolve the closest location to associate with the member
+This parameter must be accompanied by "lat" and "zip"</p></dd>
+  
+    <dt class="align-right bold" title="messaging_pref"><span class="">messaging_pref</span></dt>
+    <dd class="rounded-all"><p>Preference for which members may contact you via the Meetup platform.
+Value may be one of "all_members", "groups_only", or "orgs_only"</p></dd>
+  
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all"><p>Member name</p></dd>
+  
+    <dt class="align-right bold" title="photo_id"><span class="">photo_id</span></dt>
+    <dd class="rounded-all"><p>A valid photo id to this member has previously updated to use as profile photo</p></dd>
+  
+    <dt class="align-right bold" title="remove_topics"><span class="">remove_topics</span></dt>
+    <dd class="rounded-all"><p>Comma-delimited list of topic ids to remove from members interest list</p></dd>
+  
+    <dt class="align-right bold" title="sync_photo"><span class="">sync_photo</span></dt>
+    <dd class="rounded-all"><p>When set to true, this parameter will sync all the group
+profile photos for the member with the provided photo_id</p></dd>
+  
+    <dt class="align-right bold" title="topics_privacy"><span class="">topics_privacy</span></dt>
+    <dd class="rounded-all"><p>Preference for hiding or showing member interests to others.
+Value may be one of "hidden" or "visible"</p></dd>
+  
+    <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+    <dd class="rounded-all"><p>A valid zip code to associate with the member.
+This parameter must be accompanied by "lat" and "lon"</p></dd>
+  
+  </dl>
+  
+  <h3 id="editresponse" class="rounded-all">Response</h3>
+  <p>A successful HTTP PATCH request will return an
+updated representation of the Member Profile</p>
+  <dl>
+   
+    <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+    <dd class="rounded-all">
+    <p>Member bio. When profile does not belong to the authenticated member, this may be omitted if member opted to hide their bio from others</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="birthday"><span class="">birthday</span></dt>
+    <dd class="rounded-all">
+    <p>Returned only when the fields request parameter value includes 'birthday'
+and only for the authenticated member when defined</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="day"><span class="">day</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric day member was born. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="month"><span class="">month</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric month member was born. May be absent if not defined</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="year"><span class="">year</span></dt>
+       <dd class="rounded-all">
+        <p>Year member was born</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country code associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="email"><span class="">email</span></dt>
+    <dd class="rounded-all">
+    <p>Member email address. Provided only if a profile belongs to the authenticated member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="gender"><span class="">gender</span></dt>
+    <dd class="rounded-all">
+    <p>Returned only when the fields request parameter value includes "gender"
+and only for the authenticated member.
+Value may be one of "female", "male", "none", or "other".
+This field may be absent where gender is not defined</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Unique numeric identifier for the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_pro_admin"><span class="">is_pro_admin</span></dt>
+    <dd class="rounded-all">
+    <p>Returns true if the member is an active admin of an active meetup pro network</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="joined"><span class="">joined</span></dt>
+    <dd class="rounded-all">
+    <p>Time member joined, represented as milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="last_event"><span class="">last_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the last RSVP'd Meetup this member attended within the last two weeks,
+where available. Returned when the "fields"
+request parameter value contains "last_event"
+only for the profile of the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+       <dd class="rounded-all">
+        <p>Is event date matches the series pattern</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+       <dd class="rounded-all">
+        <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Ticketing fee information for events that support payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+            <dd class="rounded-all"><p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p></dd>
+            
+            <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+            <dd class="rounded-all"><p>Amount of the fee</p></dd>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Fee description, typically "per-person"</p></dd>
+            
+            <dt class="align-right bold" title="label"><span class="">label</span></dt>
+            <dd class="rounded-all"><p>Label for fee, typically "Price"</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>Boolean flag indicating if this fee is required to RSVP</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>Group hosting the event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate group latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate group longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="region"><span class="">region</span></dt>
+            <dd class="rounded-all"><p>Language and region of the group</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of the group</p></dd>
+            
+            <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+            <dd class="rounded-all"><p>Timezone of group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric urlname identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>A unique alphanumeric identifier for event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+       <dd class="rounded-all">
+        <p>Is event happening online</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+       <dd class="rounded-all">
+        <p>The local date of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+       <dd class="rounded-all">
+        <p>The local time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+       <dd class="rounded-all">
+        <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+       <dd class="rounded-all">
+        <p>Information about photo uploads for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="event"><span class="">event</span></dt>
+            <dd class="rounded-all"><p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for photo album</p></dd>
+            
+            <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+            <dd class="rounded-all"><p>Number of photos uploaded</p></dd>
+            
+            <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+            <dd class="rounded-all"><p>A small collection of photos uploaded for this event</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Album title</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+       <dd class="rounded-all">
+        <p>The number of "yes" RSVPS an event has capacity for</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection RSVPs for members attending this event, returned when the "fields" request parameter value includes "rsvp_sample"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>Creation time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p></dd>
+            
+            <dt class="align-right bold" title="member"><span class="">member</span></dt>
+            <dd class="rounded-all"><p>Member who RSVP'd</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>Last modified time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="series"><span class="">series</span></dt>
+       <dd class="rounded-all">
+        <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Human displayable description of how often events in this series occur</p></dd>
+            
+            <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series ends/ended, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the series</p></dd>
+            
+            <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a monthly recurring series of events</p></dd>
+            
+            <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series begins/began, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the template event of the series</p></dd>
+            
+            <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a weekly recurring series of events</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+       <dd class="rounded-all">
+        <p>Contains a list of organizer-defined survey questions intended to be asked of RSVPing members.
+Returned when the "fields" request parameter
+contains "survey_questions"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric question identifier</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time for the event in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+       <dd class="rounded-all">
+        <p>The event venue, present only if selected and not hidden by an organizer</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+            <dd class="rounded-all"><p>Line 1 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+            <dd class="rounded-all"><p>Line 2 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+            <dd class="rounded-all"><p>Line 3 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="city"><span class="">city</span></dt>
+            <dd class="rounded-all"><p>City of venue</p></dd>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country code of venue</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric venue id</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+            <dd class="rounded-all"><p>The localized name of the venue's country</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Venue name</p></dd>
+            
+            <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+            <dd class="rounded-all"><p>Phone number of venue</p></dd>
+            
+            <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+            <dd class="rounded-all"><p>true if the editor of the event altered the original venues pin location, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of venue where available</p></dd>
+            
+            <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+            <dd class="rounded-all"><p>ZIP code if, venue is in US or Canada</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of members on the waitlist, if one exists</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs including guests</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Geographic latitude associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of country associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Geographic longitude associated with Member's location</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="memberships"><span class="">memberships</span></dt>
+    <dd class="rounded-all">
+    <p>Group memberships affiliated with this member.
+Returned only when fields request parameter value includes "memberships".
+This list may be omitted if the member has opted to hide their groups from others.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="member"><span class="">member</span></dt>
+       <dd class="rounded-all">
+        <p>Memberships where member holds a basic membership</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>The time this member joined the Group, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="group"><span class="">group</span></dt>
+            <dd class="rounded-all"><p>The group associated with this membership</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the Group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Membership status in this Group.
+Value may be one of
+active, blocked, pending, pending_payment or none</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>The last time this member edited their Group profile, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+            <dd class="rounded-all"><p>The last time this member visited the Group, represented as milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="organizer"><span class="">organizer</span></dt>
+       <dd class="rounded-all">
+        <p>Memberships where member is on the group's lead team</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>The time this member joined the Group, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="group"><span class="">group</span></dt>
+            <dd class="rounded-all"><p>The group associated with this membership</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the Group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Membership status in this Group.
+Value may be one of
+active, blocked, pending, pending_payment or none</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>The last time this member edited their Group profile, represented as milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+            <dd class="rounded-all"><p>The last time this member visited the Group, represented as milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="messaging_pref"><span class="">messaging_pref</span></dt>
+    <dd class="rounded-all">
+    <p>The member's preference for being contacted from other members on the platform.
+Returned only when the fields request parameter value includes "messaging_pref".
+May be one of the following: "all_members", "groups_only", or "orgs_only"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Display name for the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="next_event"><span class="">next_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing either the current ongoing or next RSVP'd Meetup, where available.
+Returned when the "fields"
+request parameter value contains "next_event"
+only for the profile of the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+       <dd class="rounded-all">
+        <p>Is event date matches the series pattern</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+       <dd class="rounded-all">
+        <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Ticketing fee information for events that support payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+            <dd class="rounded-all"><p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p></dd>
+            
+            <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+            <dd class="rounded-all"><p>Amount of the fee</p></dd>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Fee description, typically "per-person"</p></dd>
+            
+            <dt class="align-right bold" title="label"><span class="">label</span></dt>
+            <dd class="rounded-all"><p>Label for fee, typically "Price"</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>Boolean flag indicating if this fee is required to RSVP</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>Group hosting the event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate group latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate group longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="region"><span class="">region</span></dt>
+            <dd class="rounded-all"><p>Language and region of the group</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of the group</p></dd>
+            
+            <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+            <dd class="rounded-all"><p>Timezone of group</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric urlname identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>A unique alphanumeric identifier for event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+       <dd class="rounded-all">
+        <p>Is event happening online</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+       <dd class="rounded-all">
+        <p>The local date of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+       <dd class="rounded-all">
+        <p>The local time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+       <dd class="rounded-all">
+        <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+       <dd class="rounded-all">
+        <p>Information about photo uploads for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="event"><span class="">event</span></dt>
+            <dd class="rounded-all"><p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for photo album</p></dd>
+            
+            <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+            <dd class="rounded-all"><p>Number of photos uploaded</p></dd>
+            
+            <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+            <dd class="rounded-all"><p>A small collection of photos uploaded for this event</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Album title</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+       <dd class="rounded-all">
+        <p>The number of "yes" RSVPS an event has capacity for</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection RSVPs for members attending this event, returned when the "fields" request parameter value includes "rsvp_sample"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>Creation time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p></dd>
+            
+            <dt class="align-right bold" title="member"><span class="">member</span></dt>
+            <dd class="rounded-all"><p>Member who RSVP'd</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>Last modified time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="series"><span class="">series</span></dt>
+       <dd class="rounded-all">
+        <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Human displayable description of how often events in this series occur</p></dd>
+            
+            <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series ends/ended, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the series</p></dd>
+            
+            <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a monthly recurring series of events</p></dd>
+            
+            <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series begins/began, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the template event of the series</p></dd>
+            
+            <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a weekly recurring series of events</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+       <dd class="rounded-all">
+        <p>Contains a list of organizer-defined survey questions intended to be asked of RSVPing members.
+Returned when the "fields" request parameter
+contains "survey_questions"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric question identifier</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time for the event in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+       <dd class="rounded-all">
+        <p>The event venue, present only if selected and not hidden by an organizer</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+            <dd class="rounded-all"><p>Line 1 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+            <dd class="rounded-all"><p>Line 2 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+            <dd class="rounded-all"><p>Line 3 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="city"><span class="">city</span></dt>
+            <dd class="rounded-all"><p>City of venue</p></dd>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country code of venue</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric venue id</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+            <dd class="rounded-all"><p>The localized name of the venue's country</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Venue name</p></dd>
+            
+            <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+            <dd class="rounded-all"><p>Phone number of venue</p></dd>
+            
+            <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+            <dd class="rounded-all"><p>true if the editor of the event altered the original venues pin location, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of venue where available</p></dd>
+            
+            <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+            <dd class="rounded-all"><p>ZIP code if, venue is in US or Canada</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of members on the waitlist, if one exists</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs including guests</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="other_services"><span class="">other_services</span></dt>
+    <dd class="rounded-all">
+    <p>An object whose key's are the names of associated external
+networks and values are identities within those networks.
+The keys may be one of facebook, flickr, linkedin, tumblr or twitter.
+Returned only when "fields" request parameter value
+includes "other_services"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="identifier"><span class="">identifier</span></dt>
+       <dd class="rounded-all">
+        <p>A unique string identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="url"><span class="">url</span></dt>
+       <dd class="rounded-all">
+        <p>A url for this identity. May be the same as identifier in some cases</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+    <dd class="rounded-all">
+    <p>Member photo. May be absent if member has not chosen one.
+In group contexts, the Member's Group profile photo will be returned.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="privacy"><span class="">privacy</span></dt>
+    <dd class="rounded-all">
+    <p>Member's privacy preferences
+Returned only when the "fields" request parameter value includes "privacy"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="facebook"><span class="">facebook</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' of 'visible'.
+If absent, the member has not connected their Facebook account to Meetup</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>may be 'hidden' or 'visible'</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Represents the authenticated member's relation to member.
+Returned when "fields" request parameter value includes "self" and
+the target member is not the authenticated member</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions available for the authenticated member to perform.
+Currently only "message" is supported</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="blocks"><span class="">blocks</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indication of whether or not the authenticated member blocks this member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="common"><span class="">common</span></dt>
+       <dd class="rounded-all">
+        <p>Information the authenticated member has in common with this member</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+            <dd class="rounded-all"><p>List of common groups</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="friends"><span class="">friends</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indication of whether or not the authenticated member is a friend of the member</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State associated with Member's location, where available</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="stats"><span class="">stats</span></dt>
+    <dd class="rounded-all">
+    <p>High level numeric member statistics
+Returned only when fields request parameter value includes 'stats'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="groups"><span class="">groups</span></dt>
+       <dd class="rounded-all">
+        <p>Number of Meetup Group memberships.
+May be 0 if member chose to hide their groups from others</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvps"><span class="">rsvps</span></dt>
+       <dd class="rounded-all">
+        <p>Number of RSVPs.
+May be 0 if member chose to hide their groups from others</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>Number of Meetup topics member is interested in.
+May be 0 if member chose to hide their topics from others</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>a string with one of the following values: {'active', 'prereg', 'unknown'}</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+    <dd class="rounded-all">
+    <p>List of Meetup topics Member has interest in.
+Returned only when fields request parameter value includes "topics".
+This list may be omitted when member has opted to hide the topics from others.</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+       <dd class="rounded-all">
+        <p>Language topic originates from</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+       <dd class="rounded-all">
+        <p>The unique keyword used to identify this topic</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_members_:member_id_photos.html
+++ b/test/data/_members_:member_id_photos.html
@@ -1,0 +1,132 @@
+
+        
+
+<div id="post">
+  <h2>Member Photo Upload</h2>
+  <div id="posturi" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /members/:member_id/photos
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">profile_edit</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Support for uploading new Member photos</p>
+  </div>
+  
+  <h3 id="postparams" class="rounded-all">Request Parameters</h3>
+  <div class="postparam-notes"><p>A valid path parameter value for <strong>:member_id</strong> is required. This value must match the authenticated
+member's id or "self".</p>
+<p>Since this method can change properties of your member profile, OAuth authenticated applications must
+request the <a href="/meetup_api/auth/#profile_edit_scope">profile_edit</a>
+permission scope.</p>
+<p>This method expects an HTTP POST containing a body with Content-Type of <code>multipart/form-data</code>.
+Only the <code>photo</code> parameter, which represents the photo being uploaded, is required.</p>
+<p>Uploaded photos are fed into a separate photo staging process and may not be
+immediately available for display. To receive responses for photos that are immediately
+displayable, send the <code>await</code> request parameter with a value of <code>true</code>.</p>
+<p>Authentication credentials must be omitted from the request body and be sent via
+HTTP Authorization header or as query string parameters</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="await"><span class="">await</span></dt>
+    <dd class="rounded-all"><p>Optional boolean parameter that, when set to true, will defer a request's a response until confirmation that photo is immediately displayable is received.</p></dd>
+  
+    <dt class="align-right bold" title="main"><span class="">main</span></dt>
+    <dd class="rounded-all"><p>Optional boolean parameter that, when set to true, will cause the member's main profile photo to be set to the uploaded photo</p></dd>
+  
+    <dt class="align-right bold" title="photo"><span class="param_required">photo</span></dt>
+    <dd class="rounded-all"><p>Photo upload data, encoded as a multipart/form-data file. The maximum file size allowed is 10MB</p></dd>
+  
+    <dt class="align-right bold" title="sync_photo"><span class="">sync_photo</span></dt>
+    <dd class="rounded-all"><p>Optional boolean parameter that, when set to true, will sync all of the group profile photos for the member with the provided photo</p></dd>
+  
+  </dl>
+  
+  <h3 id="postresponse" class="rounded-all">Response</h3>
+  <p>A successful request will respond with a Photo object
+If a successful photo upload is immediately accessible, a 201 Created status is returned, otherwise a 202 Accepted status is returned</p>
+  <dl>
+   
+    <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+    <dd class="rounded-all">
+    <p>A base url that can be use to construct a photo url from its components</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for full sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric photo ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for standard sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+    <dd class="rounded-all">
+    <p>Link for thumbnail sized photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="type"><span class="">type</span></dt>
+    <dd class="rounded-all">
+    <p>Type of photo. One of "event" or "member"</p>
+    
+    </dd>
+  
+  </dl>
+  
+  <h4 id="posterrors" class="rounded-all">Errors</h4>
+  <dl>
+  
+    <dt class="align-right bold"><span class="">photo_error</span></dt>
+    <dd><p>Returned photo was either omitted from the request or was invalid</p></dd>
+  
+    <dt class="align-right bold"><span class="">upload_error</span></dt>
+    <dd><p>The process of uploading the photo failed</p></dd>
+  
+    <dt class="align-right bold"><span class="">upload_timeout_error</span></dt>
+    <dd><p>An awaited response timed out</p></dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_members_:member_id_photos_:photo_id.html
+++ b/test/data/_members_:member_id_photos_:photo_id.html
@@ -1,0 +1,73 @@
+
+        
+
+<div id="delete">
+  <h2>Member Photo Delete</h2>
+  <div id="deleteuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">DELETE</strong> /members/:member_id/photos/:photo_id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">profile_edit</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Deletes a member photo by id</p>
+  </div>
+  
+  <h3 id="deleteparams" class="rounded-all">Request Parameters</h3>
+  <div class="deleteparam-notes"><p>A valid path parameter value for <strong>:member_id</strong> and <strong>:photo_id</strong> is required. The value of <strong>:member_id</strong> must match the authenticated
+member's id or "self".</p>
+<p>Since this method can change properties of your member profile, OAuth authenticated applications must
+request the <a href="/meetup_api/auth/#profile_edit_scope">profile_edit</a>
+permission scope.</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="deleteresponse" class="rounded-all">Response</h3>
+  <p>A successful request will yield an HTTP 204 NoContent response</p>
+  <dl>
+  
+  </dl>
+  
+  <h4 id="deleteerrors" class="rounded-all">Errors</h4>
+  <dl>
+  
+    <dt class="align-right bold"><span class="">authorization_error</span></dt>
+    <dd><p>Returned if the authenticated member was not the owner of this photo</p></dd>
+  
+    <dt class="align-right bold"><span class="">photo_id_error</span></dt>
+    <dd><p>Returned if the photo could not be found or was previously deleted</p></dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_notifications.html
+++ b/test/data/_notifications.html
@@ -1,0 +1,297 @@
+
+        
+
+<div id="">
+  <h2>Notifications</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /notifications
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Returns all recent Meetup notifications for the authorized member. To mark notifications read use <a href="/meetup_api/docs/notifications/read/">/notifications/read</a> endpoint. To get the authenticated Member's current unread count, request it in an <a href="/meetup_api/docs/#meta-headers">HTTP header</a>.</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/notifications">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>No parameters are required</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>Request that additional fields (separated by commas) be included in the output.</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>The response includes a JSON-encoded list of current notification items.</p>
+  <dl>
+   
+    <dt class="align-right bold" title="category"><span class="">category</span></dt>
+    <dd class="rounded-all">
+    <p>Identifier indicating a high level categorization of related kinds.</p>
+<p>This may be one of comment, default, event, group, money, photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>A unique identifier for a notification</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="important"><span class="">important</span></dt>
+    <dd class="rounded-all">
+    <p>True or False indicating a notification's level of importance</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="kind"><span class="">kind</span></dt>
+    <dd class="rounded-all">
+    <p>Identifier indicating the kind of notification.</p>
+<p>This may be one of attendance_reminder, comment, custom, donation_expire_notice, donation_potential_payment, dues, dues_confirm, dues_trial_notice, event_announce, event_announce_to_orgs, event_announce_untrusted, event_cancel, event_change, event_interest_org_push, event_reminder, external_url, final_attendance_reminder, group_announce, group_announce_push, invitation_acceptance, join, like, mug_comm_announce, mug_comm_comment, mug_comm_comment_like, mug_comm_conversation_like, mug_comm_invite, org_approve, outside_mup_rec, pending_member, photo, photo_tag, post_attendance, post_event_feedback, reply, rsvp, rsvp_confirm, saved_event_reminder, spot_open, webview_url</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to resource notification was triggered by</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+    <dd class="rounded-all">
+    <p>A photo related to the notifications. Potentially absent</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_type"><span class="">photo_type</span></dt>
+    <dd class="rounded-all">
+    <p>Type of photo, event or member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="read"><span class="">read</span></dt>
+    <dd class="rounded-all">
+    <p>True or False indicating whether a notification has been read</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Information pertaining the authorized member associated with this notification</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="action"><span class="">action</span></dt>
+       <dd class="rounded-all">
+        <p>An action that may be performed on this notification.</p>
+<p>For <code>group_announce</code> notifications this may be 'instant_join', meaning the group
+associated with the notification may be joined without filling out profile
+information, or 'form_join', the group associated with the notification requires
+some join information.</p>
+<p><code>event_announce</code> and <code>spot_open</code> notifications this may be 'instant_rsvp', meaning
+the event may be RSVP'd to without requiring additional input, or 'form_rsvp',
+meaning the event may require some input on the current member's behalf before
+RSVPing.</p>
+<p>For <code>event_reminder</code> notifications this may be 'instant_rsvp' if recipient is
+a non-rsvper or 'instant_rsvp_no' if recipient is a yes rsvper.</p>
+<p>For <code>pending_member</code> notifications this may be 'approve_member'.</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="setting"><span class="">setting</span></dt>
+    <dd class="rounded-all">
+    <p>The setting that controls the member's preference for receiving sendings of this kind of notification</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="email"><span class="">email</span></dt>
+       <dd class="rounded-all">
+        <p>A push setting if available</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>display code</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="push"><span class="">push</span></dt>
+       <dd class="rounded-all">
+        <p>An email setting if available</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>display code</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="target"><span class="">target</span></dt>
+    <dd class="rounded-all">
+    <p>kind specific properties which may be used to navigate back to the source of the notification</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="album_id"><span class="">album_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, a numeric photo album ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="comment_id"><span class="">comment_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the numeric ID of the comment which relates to this notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="comment_parent_id"><span class="">comment_parent_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the numeric ID of the top-level comment which relates to this notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_id"><span class="">event_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the alphanumeric ID of the event which relates to this notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="group_id"><span class="">group_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the numeric ID of the group which relates to this notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="group_urlname"><span class="">group_urlname</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the alpha numeric urlname of the group which relates to this notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="member_id"><span class="">member_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the numeric ID of the member involved in the notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="pending"><span class="">pending</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, a boolean valid indicating the membership status of member_id in the context of a group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_id"><span class="">photo_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, a numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Identifier indicating the view that should be navigated to.</p>
+<p>These may be one of: group, group_member_list, group_member_profile, event, topic_picker, calendar, group_list, event_photos, event_comments, friends_calendar, friends_groups, start_group, external_url, event_location, deeplink_url</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="text"><span class="">text</span></dt>
+    <dd class="rounded-all">
+    <p>Notification content as text</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>The last time the notification was modified, indicated as the time in milliseconds since the epoch</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_notifications_clicked.html
+++ b/test/data/_notifications_clicked.html
@@ -1,0 +1,297 @@
+
+        
+
+<div id="">
+  <h2>Clicked Notifications</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /notifications/clicked
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Marks groups of <a href="/meetup_api/docs/notifications/">notifications</a> as clicked.</p>
+  </div>
+  
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="notif_id"><span class="">notif_id</span></dt>
+    <dd class="rounded-all"><p>The id of the notification to set as clicked</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>The response includes a JSON-encoded list of current notification items</p>
+  <dl>
+   
+    <dt class="align-right bold" title="category"><span class="">category</span></dt>
+    <dd class="rounded-all">
+    <p>Identifier indicating a high level categorization of related kinds.</p>
+<p>This may be one of comment, default, event, group, money, photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>A unique identifier for a notification</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="important"><span class="">important</span></dt>
+    <dd class="rounded-all">
+    <p>True or False indicating a notification's level of importance</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="kind"><span class="">kind</span></dt>
+    <dd class="rounded-all">
+    <p>Identifier indicating the kind of notification.</p>
+<p>This may be one of attendance_reminder, comment, custom, donation_expire_notice, donation_potential_payment, dues, dues_confirm, dues_trial_notice, event_announce, event_announce_to_orgs, event_announce_untrusted, event_cancel, event_change, event_interest_org_push, event_reminder, external_url, final_attendance_reminder, group_announce, group_announce_push, invitation_acceptance, join, like, mug_comm_announce, mug_comm_comment, mug_comm_comment_like, mug_comm_conversation_like, mug_comm_invite, org_approve, outside_mup_rec, pending_member, photo, photo_tag, post_attendance, post_event_feedback, reply, rsvp, rsvp_confirm, saved_event_reminder, spot_open, webview_url</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to resource notification was triggered by</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+    <dd class="rounded-all">
+    <p>A photo related to the notifications. Potentially absent</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_type"><span class="">photo_type</span></dt>
+    <dd class="rounded-all">
+    <p>Type of photo, event or member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="read"><span class="">read</span></dt>
+    <dd class="rounded-all">
+    <p>True or False indicating whether a notification has been read</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Information pertaining the authorized member associated with this notification</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="action"><span class="">action</span></dt>
+       <dd class="rounded-all">
+        <p>An action that may be performed on this notification.</p>
+<p>For <code>group_announce</code> notifications this may be 'instant_join', meaning the group
+associated with the notification may be joined without filling out profile
+information, or 'form_join', the group associated with the notification requires
+some join information.</p>
+<p><code>event_announce</code> and <code>spot_open</code> notifications this may be 'instant_rsvp', meaning
+the event may be RSVP'd to without requiring additional input, or 'form_rsvp',
+meaning the event may require some input on the current member's behalf before
+RSVPing.</p>
+<p>For <code>event_reminder</code> notifications this may be 'instant_rsvp' if recipient is
+a non-rsvper or 'instant_rsvp_no' if recipient is a yes rsvper.</p>
+<p>For <code>pending_member</code> notifications this may be 'approve_member'.</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="setting"><span class="">setting</span></dt>
+    <dd class="rounded-all">
+    <p>The setting that controls the member's preference for receiving sendings of this kind of notification</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="email"><span class="">email</span></dt>
+       <dd class="rounded-all">
+        <p>A push setting if available</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>display code</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="push"><span class="">push</span></dt>
+       <dd class="rounded-all">
+        <p>An email setting if available</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>display code</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="target"><span class="">target</span></dt>
+    <dd class="rounded-all">
+    <p>kind specific properties which may be used to navigate back to the source of the notification</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="album_id"><span class="">album_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, a numeric photo album ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="comment_id"><span class="">comment_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the numeric ID of the comment which relates to this notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="comment_parent_id"><span class="">comment_parent_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the numeric ID of the top-level comment which relates to this notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_id"><span class="">event_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the alphanumeric ID of the event which relates to this notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="group_id"><span class="">group_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the numeric ID of the group which relates to this notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="group_urlname"><span class="">group_urlname</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the alpha numeric urlname of the group which relates to this notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="member_id"><span class="">member_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the numeric ID of the member involved in the notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="pending"><span class="">pending</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, a boolean valid indicating the membership status of member_id in the context of a group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_id"><span class="">photo_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, a numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Identifier indicating the view that should be navigated to.</p>
+<p>These may be one of: group, group_member_list, group_member_profile, event, topic_picker, calendar, group_list, event_photos, event_comments, friends_calendar, friends_groups, start_group, external_url, event_location, deeplink_url</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="text"><span class="">text</span></dt>
+    <dd class="rounded-all">
+    <p>Notification content as text</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>The last time the notification was modified, indicated as the time in milliseconds since the epoch</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_notifications_read.html
+++ b/test/data/_notifications_read.html
@@ -1,0 +1,300 @@
+
+        
+
+<div id="">
+  <h2>Read Notifications</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /notifications/read
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Marks groups of <a href="/meetup_api/docs/notifications/">notifications</a> as read.</p>
+  </div>
+  
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>Request that additional fields (separated by commas) be included in the output.</p></dd>
+  
+    <dt class="align-right bold" title="since_id"><span class="">since_id</span></dt>
+    <dd class="rounded-all"><p>The id of the newest notification item, typically the first in the list returned by the notifications endpoint</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>The response includes a JSON-encoded list of current notification items</p>
+  <dl>
+   
+    <dt class="align-right bold" title="category"><span class="">category</span></dt>
+    <dd class="rounded-all">
+    <p>Identifier indicating a high level categorization of related kinds.</p>
+<p>This may be one of comment, default, event, group, money, photo</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>A unique identifier for a notification</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="important"><span class="">important</span></dt>
+    <dd class="rounded-all">
+    <p>True or False indicating a notification's level of importance</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="kind"><span class="">kind</span></dt>
+    <dd class="rounded-all">
+    <p>Identifier indicating the kind of notification.</p>
+<p>This may be one of attendance_reminder, comment, custom, donation_expire_notice, donation_potential_payment, dues, dues_confirm, dues_trial_notice, event_announce, event_announce_to_orgs, event_announce_untrusted, event_cancel, event_change, event_interest_org_push, event_reminder, external_url, final_attendance_reminder, group_announce, group_announce_push, invitation_acceptance, join, like, mug_comm_announce, mug_comm_comment, mug_comm_comment_like, mug_comm_conversation_like, mug_comm_invite, org_approve, outside_mup_rec, pending_member, photo, photo_tag, post_attendance, post_event_feedback, reply, rsvp, rsvp_confirm, saved_event_reminder, spot_open, webview_url</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to resource notification was triggered by</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+    <dd class="rounded-all">
+    <p>A photo related to the notifications. Potentially absent</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_type"><span class="">photo_type</span></dt>
+    <dd class="rounded-all">
+    <p>Type of photo, event or member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="read"><span class="">read</span></dt>
+    <dd class="rounded-all">
+    <p>True or False indicating whether a notification has been read</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Information pertaining the authorized member associated with this notification</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="action"><span class="">action</span></dt>
+       <dd class="rounded-all">
+        <p>An action that may be performed on this notification.</p>
+<p>For <code>group_announce</code> notifications this may be 'instant_join', meaning the group
+associated with the notification may be joined without filling out profile
+information, or 'form_join', the group associated with the notification requires
+some join information.</p>
+<p><code>event_announce</code> and <code>spot_open</code> notifications this may be 'instant_rsvp', meaning
+the event may be RSVP'd to without requiring additional input, or 'form_rsvp',
+meaning the event may require some input on the current member's behalf before
+RSVPing.</p>
+<p>For <code>event_reminder</code> notifications this may be 'instant_rsvp' if recipient is
+a non-rsvper or 'instant_rsvp_no' if recipient is a yes rsvper.</p>
+<p>For <code>pending_member</code> notifications this may be 'approve_member'.</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="setting"><span class="">setting</span></dt>
+    <dd class="rounded-all">
+    <p>The setting that controls the member's preference for receiving sendings of this kind of notification</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="email"><span class="">email</span></dt>
+       <dd class="rounded-all">
+        <p>A push setting if available</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>display code</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="push"><span class="">push</span></dt>
+       <dd class="rounded-all">
+        <p>An email setting if available</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>display code</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="target"><span class="">target</span></dt>
+    <dd class="rounded-all">
+    <p>kind specific properties which may be used to navigate back to the source of the notification</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="album_id"><span class="">album_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, a numeric photo album ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="comment_id"><span class="">comment_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the numeric ID of the comment which relates to this notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="comment_parent_id"><span class="">comment_parent_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the numeric ID of the top-level comment which relates to this notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_id"><span class="">event_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the alphanumeric ID of the event which relates to this notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="group_id"><span class="">group_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the numeric ID of the group which relates to this notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="group_urlname"><span class="">group_urlname</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the alpha numeric urlname of the group which relates to this notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="member_id"><span class="">member_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, the numeric ID of the member involved in the notification</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="pending"><span class="">pending</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, a boolean valid indicating the membership status of member_id in the context of a group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_id"><span class="">photo_id</span></dt>
+       <dd class="rounded-all">
+        <p>If needed, a numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Identifier indicating the view that should be navigated to.</p>
+<p>These may be one of: group, group_member_list, group_member_profile, event, topic_picker, calendar, group_list, event_photos, event_comments, friends_calendar, friends_groups, start_group, external_url, event_location, deeplink_url</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="text"><span class="">text</span></dt>
+    <dd class="rounded-all">
+    <p>Notification content as text</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>The last time the notification was modified, indicated as the time in milliseconds since the epoch</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_pro_:urlname_events.html
+++ b/test/data/_pro_:urlname_events.html
@@ -1,0 +1,985 @@
+
+        
+
+<div id="">
+  <h2>Ordered set of upcoming events from groups affiliated to the Pro Organization</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /pro/:urlname/events
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>An ordered set of timeboxed events from the groups in the Pro Organization</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/pro/:urlname/events">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>All parameters are optional.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all"><p>String: Country</p></dd>
+  
+    <dt class="align-right bold" title="eventsType"><span class="">eventsType</span></dt>
+    <dd class="rounded-all"><p>String: type of events to fetch. Accepted values:
+'online', 'inPerson' and 'both'. 'both' type is by default</p></dd>
+  
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all"><p>Float: Latitude</p></dd>
+  
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all"><p>Float: Longitude</p></dd>
+  
+    <dt class="align-right bold" title="radius"><span class="">radius</span></dt>
+    <dd class="rounded-all"><p>Float: search radius. Max accepted value: 200.0. By default, radius for events is Infinity</p></dd>
+  
+    <dt class="align-right bold" title="size"><span class="">size</span></dt>
+    <dd class="rounded-all"><p>Integer: amount of events to pull. By default: 8. Max value: 100</p></dd>
+  
+    <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+    <dd class="rounded-all"><p>String: Zip code</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="chapter"><span class="">chapter</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the associated chapter</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="average_age"><span class="">average_age</span></dt>
+       <dd class="rounded-all">
+        <p>Average age of the group members</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="category"><span class="">category</span></dt>
+       <dd class="rounded-all">
+        <p>Categories that the group belongs to</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Id of the category</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the category</p></dd>
+            
+            <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+            <dd class="rounded-all"><p>Abbreviated name of the category</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="city"><span class="">city</span></dt>
+       <dd class="rounded-all">
+        <p>City of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="description"><span class="">description</span></dt>
+       <dd class="rounded-all">
+        <p>Description of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="founded_date"><span class="">founded_date</span></dt>
+       <dd class="rounded-all">
+        <p>Date when the group was founded</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="gender_female"><span class="">gender_female</span></dt>
+       <dd class="rounded-all">
+        <p>Proportion of members who identify as female</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="gender_male"><span class="">gender_male</span></dt>
+       <dd class="rounded-all">
+        <p>Proportion of members who identify as male</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="gender_other"><span class="">gender_other</span></dt>
+       <dd class="rounded-all">
+        <p>Proportion of members who identify as gender other than male or female</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="gender_unknown"><span class="">gender_unknown</span></dt>
+       <dd class="rounded-all">
+        <p>Proportion of members whose gender is unknown</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Id of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="last_event"><span class="">last_event</span></dt>
+       <dd class="rounded-all">
+        <p>Date of the last meetup event, not present if the group never had a meetup event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="member_count"><span class="">member_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of the group members</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="next_event"><span class="">next_event</span></dt>
+       <dd class="rounded-all">
+        <p>Date of the next meetup event, not present if the group has no event scheduled</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_events"><span class="">past_events</span></dt>
+       <dd class="rounded-all">
+        <p>Number of the past meetup events</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_rsvps"><span class="">past_rsvps</span></dt>
+       <dd class="rounded-all">
+        <p>Number of total RSVPs in the past</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="pro_join_date"><span class="">pro_join_date</span></dt>
+       <dd class="rounded-all">
+        <p>Date when the group joined the Pro organization</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="repeat_rsvpers"><span class="">repeat_rsvpers</span></dt>
+       <dd class="rounded-all">
+        <p>Number of members who RSVPed to a past event and RSVPs to a new event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvps_per_event"><span class="">rsvps_per_event</span></dt>
+       <dd class="rounded-all">
+        <p>Average number of RSVPs per event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State of the group, if in US or Canada</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Status of the group, one of Active | Delisted | Inactive</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>Topics that are assigned to the group</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Id of the topic</p></dd>
+            
+            <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+            <dd class="rounded-all"><p>Locale of the topic</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the topic</p></dd>
+            
+            <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+            <dd class="rounded-all"><p>Urlkey used to identify the topic on meetup.com</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="upcoming_events"><span class="">upcoming_events</span></dt>
+       <dd class="rounded-all">
+        <p>Number of the upcoming meetup events</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="event"><span class="">event</span></dt>
+    <dd class="rounded-all">
+    <p>Description of event</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="attendance_count"><span class="">attendance_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of all members marked as attended, yes RSVPs that were not changed by attendance and their guests</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="attendance_sample"><span class="">attendance_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection of members marked as attended and yes RSVPs that were not changed by attendance</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="attendee_sample"><span class="">attendee_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection of attendance records of members marked as attended and yes RSVPs that were not changed by attendance. For upcoming events, this represents collection of yes RSVPs</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="comment_count"><span class="">comment_count</span></dt>
+       <dd class="rounded-all">
+        <p>An aggregate count of all comments and replies for a given event, returned when fields request parameter value includes 'comment_count'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+       <dd class="rounded-all">
+        <p>Is event date matches the series pattern</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="description"><span class="">description</span></dt>
+       <dd class="rounded-all">
+        <p>Description of the event in HTML. Email addresses and phone numbers will be masked for non-members</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="description_images"><span class="">description_images</span></dt>
+       <dd class="rounded-all">
+        <p>A list of image urls included in the event description.  returned when "fields" request parameter value contains "description_images, only supported for GET /event/:id currently"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+       <dd class="rounded-all">
+        <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="event_hosts"><span class="">event_hosts</span></dt>
+       <dd class="rounded-all">
+        <p>List of members hosting the event, returned when fields request parameter value includes 'event_hosts'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="host_count"><span class="">host_count</span></dt>
+            <dd class="rounded-all"><p>Number of times member hosted for group</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Host member's id</p></dd>
+            
+            <dt class="align-right bold" title="intro"><span class="">intro</span></dt>
+            <dd class="rounded-all"><p>Host member's introduction</p></dd>
+            
+            <dt class="align-right bold" title="join_date"><span class="">join_date</span></dt>
+            <dd class="rounded-all"><p>Group join date in milliseconds since epoch</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Host member's name</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Member photo if one exists</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="featured"><span class="">featured</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean indicator of whether or not a given event is featured, returned when fields request parameter value includes 'featured'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="featured_photo"><span class="">featured_photo</span></dt>
+       <dd class="rounded-all">
+        <p>A featured photo for this event, returned when the 'fields' request paramater includes 'featured_photo'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Ticketing fee information for events that support payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+            <dd class="rounded-all"><p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p></dd>
+            
+            <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+            <dd class="rounded-all"><p>Amount of the fee</p></dd>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Fee description, typically "per-person"</p></dd>
+            
+            <dt class="align-right bold" title="label"><span class="">label</span></dt>
+            <dd class="rounded-all"><p>Label for fee, typically "Price"</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>Boolean flag indicating if this fee is required to RSVP</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="fee_options"><span class="">fee_options</span></dt>
+       <dd class="rounded-all">
+        <p>Payment options for event ticketing, returned when the 'fields' request parameter value includes 'fee_options'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="currencies"><span class="">currencies</span></dt>
+            <dd class="rounded-all"><p>Acceptable currencies for the payment method specified by type</p></dd>
+            
+            <dt class="align-right bold" title="is_setup"><span class="">is_setup</span></dt>
+            <dd class="rounded-all"><p>A boolean set to true if the payment method specified by 'type' is set up for the group</p></dd>
+            
+            <dt class="align-right bold" title="setup_link"><span class="">setup_link</span></dt>
+            <dd class="rounded-all"><p>The URL for setting up the payment method specified by 'type'. This is returned if the payment method specified by 'type' is not set up for the group and the member has the permission to set it up</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Acceptable methods of payments may be one of Set(stripe, wepay, paypal, none, cash)</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="group"><span class="">group</span></dt>
+       <dd class="rounded-all">
+        <p>Information about group hosting the event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="category"><span class="">category</span></dt>
+            <dd class="rounded-all"><p>Category group belongs to, returned when fields request parameter value includes 'group_category'</p></dd>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="join_info"><span class="">join_info</span></dt>
+            <dd class="rounded-all"><p>Lists any questions requested when joining and required fields. Returned with "fields" request parameter value includes "group_join_info"</p></dd>
+            
+            <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+            <dd class="rounded-all"><p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p></dd>
+            
+            <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+            <dd class="rounded-all"><p>Group primary photo, returned when fields request parameter value includes 'group_key_photo'</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate group latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+            <dd class="rounded-all"><p>City/State or City/Country of the group</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate group longitude</p></dd>
+            
+            <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+            <dd class="rounded-all"><p>Membership dues information associated with hosting group, returned when fields request parameter value includes 'group_membership_dues'</p></dd>
+            
+            <dt class="align-right bold" title="meta_category"><span class="">meta_category</span></dt>
+            <dd class="rounded-all"><p>The meta category of the group, if the group has one, returned when fields request parameter value inclues 'meta_category'</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of the group</p></dd>
+            
+            <dt class="align-right bold" title="past_event_count"><span class="">past_event_count</span></dt>
+            <dd class="rounded-all"><p>The number of past events belonging to the group, returned when "fields" includes "group_past_event_count"</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Photo associated with group, returned when fields request parameter value includes 'group_photo'</p></dd>
+            
+            <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+            <dd class="rounded-all"><p>Color combination used to generate group duotone, returned when fields request parameter value includes 'group_photo_gradient'</p></dd>
+            
+            <dt class="align-right bold" title="pro_network"><span class="">pro_network</span></dt>
+            <dd class="rounded-all"><p>Information on group's Pro organization, returned when "fields" request parameter value includes "group_pro_network"</p></dd>
+            
+            <dt class="align-right bold" title="region"><span class="">region</span></dt>
+            <dd class="rounded-all"><p>Language and region of the group</p></dd>
+            
+            <dt class="align-right bold" title="self"><span class="">self</span></dt>
+            <dd class="rounded-all"><p>Information pertaining to the authenticated member with respect to the group, returned when fields request parameter value includes 'group_self_profile', 'group_self_actions', 'group_self_membership_dues', or 'group_self_status'</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of the group</p></dd>
+            
+            <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+            <dd class="rounded-all"><p>Timezone of group</p></dd>
+            
+            <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+            <dd class="rounded-all"><p>Topics related to the group, returned when fields request parameter value includes 'group_topics'</p></dd>
+            
+            <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric urlname identifier for the group</p></dd>
+            
+            <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+            <dd class="rounded-all"><p>Group visibility, returned when fields request parameter value includes 'group_visibility'. Value may be "public", "public_limited", or "members".</p></dd>
+            
+            <dt class="align-right bold" title="who"><span class="">who</span></dt>
+            <dd class="rounded-all"><p>What the group calls its members</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="how_to_find_us"><span class="">how_to_find_us</span></dt>
+       <dd class="rounded-all">
+        <p>Additional information on how to find members at a venue when provided by an organizer, returned when fields request parameter value includes 'how_to_find_us'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>A unique alphanumeric identifier for event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+       <dd class="rounded-all">
+        <p>Is event happening online</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="link"><span class="">link</span></dt>
+       <dd class="rounded-all">
+        <p>Link to event on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+       <dd class="rounded-all">
+        <p>The local date of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+       <dd class="rounded-all">
+        <p>The local time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="manual_attendance_count"><span class="">manual_attendance_count</span></dt>
+       <dd class="rounded-all">
+        <p>Manually entered total attendee headcount, if any exists</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+       <dd class="rounded-all">
+        <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+       <dd class="rounded-all">
+        <p>Information about photo uploads for this event, returned when fields request parameter value includes 'photo_album'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="event"><span class="">event</span></dt>
+            <dd class="rounded-all"><p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for photo album</p></dd>
+            
+            <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+            <dd class="rounded-all"><p>Number of photos uploaded</p></dd>
+            
+            <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+            <dd class="rounded-all"><p>A small collection of photos uploaded for this event</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Album title</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="plain_text_description"><span class="">plain_text_description</span></dt>
+       <dd class="rounded-all">
+        <p>Plain text version of the event description. Email addresses and photo numbers will be masked for non-members. Returned when "fields" request parameter value contains "plain_text_description"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="plain_text_no_images_description"><span class="">plain_text_no_images_description</span></dt>
+       <dd class="rounded-all">
+        <p>Plain text version of the event description without images. Email addresses and photo numbers will be masked for non-members. Returned when "fields" request parameter value contains "plain_text_no_images_description"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+       <dd class="rounded-all">
+        <p>The number of "yes" RSVPS an event has capacity for</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp_rules"><span class="">rsvp_rules</span></dt>
+       <dd class="rounded-all">
+        <p>Information about conditions that allow for member RSVPs, returned when fields request parameter value include 'rsvp_rules'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="close_time"><span class="">close_time</span></dt>
+            <dd class="rounded-all"><p>UTC time that RSVPs will no longer be accepted, though organizers may close RSVPs earlier</p></dd>
+            
+            <dt class="align-right bold" title="closed"><span class="">closed</span></dt>
+            <dd class="rounded-all"><p>Boolean value indicating whether or not RSVPing was explicitly closed for the event.</p></dd>
+            
+            <dt class="align-right bold" title="guest_limit"><span class="">guest_limit</span></dt>
+            <dd class="rounded-all"><p>Number of guests members may include in their RSVP, 0 or more</p></dd>
+            
+            <dt class="align-right bold" title="open_time"><span class="">open_time</span></dt>
+            <dd class="rounded-all"><p>UTC time that members may begin to RSVP</p></dd>
+            
+            <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+            <dd class="rounded-all"><p>The organizer-defined terms for refunds. If this is defined, you must provide the authenticated member a way to access this information before they can RSVP. They will need to agree to these terms before they RSVP</p></dd>
+            
+            <dt class="align-right bold" title="waitlisting"><span class="">waitlisting</span></dt>
+            <dd class="rounded-all"><p>Wait list handling when RSVP limit is reached. Value may be one of 'auto', 'manual' or 'off'</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection RSVPs for members attending this event, returned when fields request parameter value includes 'rsvp_sample'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="created"><span class="">created</span></dt>
+            <dd class="rounded-all"><p>Creation time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p></dd>
+            
+            <dt class="align-right bold" title="member"><span class="">member</span></dt>
+            <dd class="rounded-all"><p>Member who RSVP'd</p></dd>
+            
+            <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+            <dd class="rounded-all"><p>Last modified time of the RSVP, in milliseconds since the epoch</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="rsvpable"><span class="">rsvpable</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean value indicating whether or not the authenticated member can RSVP or join the waitlist when the event is full.
+Returned when the "fields" request parameter value
+includes "rsvpable"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvpable_after_join"><span class="">rsvpable_after_join</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean value indicating whether or not the authenticated member can RSVP
+after joining the hosting group.
+Returned when the "fields" request parameter
+includes "rsvpable_after_join"
+and the authenticated member is <em>not</em> a member of the
+group hosting this event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="saved"><span class="">saved</span></dt>
+       <dd class="rounded-all">
+        <p>Whether the authorized member has saved the event, returned when fields request parameter value includes 'saved'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self"><span class="">self</span></dt>
+       <dd class="rounded-all">
+        <p>represents details particular to the authorized user, only present if requested and authenticated member is a member of the hosting group, returned when fields request parameter value includes 'self'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+            <dd class="rounded-all"><p>List of actions the authenticated member may perform, potentially one or more of the following</p>
+<p>"announce" to announce the event to the group's members</p>
+<p>"attendance" to view or take attendance for the event</p>
+<p>"copy" the ability to copy an event</p>
+<p>"comment" the ability to post a comment or reply</p>
+<p>"payments" the ability to mark members as paid if the event is ticketed</p>
+<p>"publish" to publish a draft event</p>
+<p>"edit" to edit the event information</p>
+<p>"edit_hosts" to edit the hosts for the event</p>
+<p>"email_attendees" the ability to email event attendees</p>
+<p>"delete" to delete the event</p>
+<p>"rsvp" to RSVP yes or no to the event</p>
+<p>"wait" to get on the waiting list (using the same RSVP methods).</p>
+<p>"dues" if an organizer requires membership dues to RSVP and the authorized
+ member has not paid theirs</p>
+<p>"upload_photo" the ability to upload a photo for the event</p>
+<p>"cancel" the ability to cancel the event</p>
+<p>"close" the ability to close the RSVPs for the event</p>
+<p>"open" the ability to open the RSVPs for the event</p>
+<p>"invite" the ability to invite someone for the event</p>
+<p>"download_attendees" the ability to download the attendees list for the event</p>
+<p>"take_attendance" the ability to take attendance for the event</p>
+<p>"delete_cancelled" the ability to delete the event if it is cancelled</p></dd>
+            
+            <dt class="align-right bold" title="pay_status"><span class="">pay_status</span></dt>
+            <dd class="rounded-all"><p>The authenticated member's payment status. This may be one of 'none', 'paid', 'partially_paid', 'payment_pending', 'echeck_pending', 'refund_pending', 'partially_refunded', 'refunded'</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The authenticated member's role in within the group, if any. This may be one of: Organizer, Assistant Organizer, Event Organizer, etc.</p></dd>
+            
+            <dt class="align-right bold" title="rsvp"><span class="">rsvp</span></dt>
+            <dd class="rounded-all"><p>Member's RSVP, if any</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="series"><span class="">series</span></dt>
+       <dd class="rounded-all">
+        <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Human displayable description of how often events in this series occur</p></dd>
+            
+            <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series ends/ended, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the series</p></dd>
+            
+            <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a monthly recurring series of events</p></dd>
+            
+            <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series begins/began, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the template event of the series</p></dd>
+            
+            <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a weekly recurring series of events</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+       <dd class="rounded-all">
+        <p>A shortened link for the event on meetup.com, returned when fields request parameter value includes "short_link"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="simple_html_description"><span class="">simple_html_description</span></dt>
+       <dd class="rounded-all">
+        <p>Description of the event, in simple HTML source format. If this event's description was saved in simple HTML format, the description field will be an HTML translation of this source. Returned when the "fields"' request parameter contains "simple_html_description"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>"cancelled", "upcoming", "past", "proposed", "suggested", or "draft"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+       <dd class="rounded-all">
+        <p>List of organizer-defined survey questions intended to be asked of RSVPing members. Returned when the "fields"' request parameter contains "answers"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric question identifier</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time for the event in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+       <dd class="rounded-all">
+        <p>The event venue, present only if selected and not hidden by an organizer</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+            <dd class="rounded-all"><p>Line 1 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+            <dd class="rounded-all"><p>Line 2 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+            <dd class="rounded-all"><p>Line 3 of venue address</p></dd>
+            
+            <dt class="align-right bold" title="city"><span class="">city</span></dt>
+            <dd class="rounded-all"><p>City of venue</p></dd>
+            
+            <dt class="align-right bold" title="country"><span class="">country</span></dt>
+            <dd class="rounded-all"><p>Country code of venue</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric venue id</p></dd>
+            
+            <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+            <dd class="rounded-all"><p>Approximate latitude</p></dd>
+            
+            <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+            <dd class="rounded-all"><p>The localized name of the venue's country</p></dd>
+            
+            <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+            <dd class="rounded-all"><p>Approximate longitude</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Venue name</p></dd>
+            
+            <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+            <dd class="rounded-all"><p>Phone number of venue</p></dd>
+            
+            <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+            <dd class="rounded-all"><p>true if the editor of the event altered the original venues pin location, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="state"><span class="">state</span></dt>
+            <dd class="rounded-all"><p>State of venue where available</p></dd>
+            
+            <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+            <dd class="rounded-all"><p>ZIP code if, venue is in US or Canada</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="venue_visibility"><span class="">venue_visibility</span></dt>
+       <dd class="rounded-all">
+        <p>Represents who can see the venue with a potential value of "members" or "public", returned when fields request parameter value includes "venue_visibility" and the authenticated member is a member of the group hosting the event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+       <dd class="rounded-all">
+        <p>Event visibility: "public", "public_limited", or "members". Events in private groups that do not expose limited information are visible only to that group's members and should not be made public.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of members on the waitlist, if one exists</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="web_actions"><span class="">web_actions</span></dt>
+       <dd class="rounded-all">
+        <p>Set of "Invite" and google/yahoo/ical/outlook "Add to calendar" web actions</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="why"><span class="">why</span></dt>
+       <dd class="rounded-all">
+        <p>We should do this because...</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs including guests</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="event_image"><span class="">event_image</span></dt>
+    <dd class="rounded-all">
+    <p>Description of event image</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_pro_:urlname_groups.html
+++ b/test/data/_pro_:urlname_groups.html
@@ -1,0 +1,443 @@
+
+        
+
+<div id="">
+  <h2>Search Pro Groups</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /pro/:urlname/groups
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Name and statistics range search for the meetup groups belonging to Pro organization.</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/pro/:urlname/groups">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>All parameters are optional. <code>order</code> and <code>desc</code> can take multiple items in a comma-delimited list.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="active_within_days"><span class="">active_within_days</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: including only those groups that had event in the last specified days</p></dd>
+  
+    <dt class="align-right bold" title="average_age_max"><span class="">average_age_max</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: Maximum range of the average age of the members</p></dd>
+  
+    <dt class="align-right bold" title="average_age_min"><span class="">average_age_min</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: Minumum range of the average age of the members</p></dd>
+  
+    <dt class="align-right bold" title="category"><span class="">category</span></dt>
+    <dd class="rounded-all"><p>List of Integers: the ids of the category of the group</p></dd>
+  
+    <dt class="align-right bold" title="chapter_urlnames"><span class="">chapter_urlnames</span></dt>
+    <dd class="rounded-all"><p>List of String: the urlnames of chapters that may belong to the organization</p></dd>
+  
+    <dt class="align-right bold" title="chapters"><span class="">chapters</span></dt>
+    <dd class="rounded-all"><p>List of Integer: the chapter ids that may belong to the organization</p></dd>
+  
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all"><p>String: Country</p></dd>
+  
+    <dt class="align-right bold" title="desc"><span class="">desc</span></dt>
+    <dd class="rounded-all"><p>List of Boolean: whether to sort ascending or decending on each attributes in <code>order</code></p></dd>
+  
+    <dt class="align-right bold" title="excluded_chapters"><span class="">excluded_chapters</span></dt>
+    <dd class="rounded-all"><p>List of Integer: the chapters to exclude from the result</p></dd>
+  
+    <dt class="align-right bold" title="founded_date_max"><span class="">founded_date_max</span></dt>
+    <dd class="rounded-all"><p>Milliseconds since epoch: Maximum range of the founded dates of the groups</p></dd>
+  
+    <dt class="align-right bold" title="founded_date_min"><span class="">founded_date_min</span></dt>
+    <dd class="rounded-all"><p>Milliseconds since epoch: Minumum range of the founded dates of the groups</p></dd>
+  
+    <dt class="align-right bold" title="inactive_within_days"><span class="">inactive_within_days</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: including only those groups that did not have event in the last specified days</p></dd>
+  
+    <dt class="align-right bold" title="last_event_max"><span class="">last_event_max</span></dt>
+    <dd class="rounded-all"><p>Milliseconds since epoch: Maximum range of the date that the last meetup happened</p></dd>
+  
+    <dt class="align-right bold" title="last_event_min"><span class="">last_event_min</span></dt>
+    <dd class="rounded-all"><p>Milliseconds since epoch: Minumum range of the date that the last meetup happened</p></dd>
+  
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all"><p>Float: Latitude</p></dd>
+  
+    <dt class="align-right bold" title="location"><span class="">location</span></dt>
+    <dd class="rounded-all"><p>String: Raw location</p></dd>
+  
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all"><p>Float: Longitude</p></dd>
+  
+    <dt class="align-right bold" title="member_count_max"><span class="">member_count_max</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: Maximum range of the number of members</p></dd>
+  
+    <dt class="align-right bold" title="member_count_min"><span class="">member_count_min</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: Minimum range of the number of members</p></dd>
+  
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all"><p>String: Name of the group looking for</p></dd>
+  
+    <dt class="align-right bold" title="next_event_max"><span class="">next_event_max</span></dt>
+    <dd class="rounded-all"><p>Milliseconds since epoch: Maximum range of the date that the next meetup is scheduled</p></dd>
+  
+    <dt class="align-right bold" title="next_event_min"><span class="">next_event_min</span></dt>
+    <dd class="rounded-all"><p>Milliseconds since epoch: Minumum range of the date that the next meetup is scheduled</p></dd>
+  
+    <dt class="align-right bold" title="offset"><span class="">offset</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: the page offset</p></dd>
+  
+    <dt class="align-right bold" title="order"><span class="">order</span></dt>
+    <dd class="rounded-all"><p>List of String: attributes to sort on</p></dd>
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: the size of page window</p></dd>
+  
+    <dt class="align-right bold" title="past_events_max"><span class="">past_events_max</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: Maximum range of the number of the past events held</p></dd>
+  
+    <dt class="align-right bold" title="past_events_min"><span class="">past_events_min</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: Minumum range of the number of the past events held</p></dd>
+  
+    <dt class="align-right bold" title="past_rsvps_max"><span class="">past_rsvps_max</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: Maximum range of the total number of past RSVPs</p></dd>
+  
+    <dt class="align-right bold" title="past_rsvps_min"><span class="">past_rsvps_min</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: Minumum range of the total number of past RSVPs</p></dd>
+  
+    <dt class="align-right bold" title="pro_join_date_max"><span class="">pro_join_date_max</span></dt>
+    <dd class="rounded-all"><p>Milliseconds since epoch: Maximum range of the dates the groups joined Pro organization</p></dd>
+  
+    <dt class="align-right bold" title="pro_join_date_min"><span class="">pro_join_date_min</span></dt>
+    <dd class="rounded-all"><p>Milliseconds since epoch: Minumum range of the dates the groups joined Pro organization</p></dd>
+  
+    <dt class="align-right bold" title="query"><span class="">query</span></dt>
+    <dd class="rounded-all"><p>String: raw query to search from group name, description, leadership member name, or city</p></dd>
+  
+    <dt class="align-right bold" title="radius"><span class="">radius</span></dt>
+    <dd class="rounded-all"><p>String: <code>global</code>, <code>smart</code>, or search radius in Float</p></dd>
+  
+    <dt class="align-right bold" title="repeat_rsvpers_max"><span class="">repeat_rsvpers_max</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: Maximum range of the average number of repeat rsvpers</p></dd>
+  
+    <dt class="align-right bold" title="repeat_rsvpers_min"><span class="">repeat_rsvpers_min</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: Minumum range of the average number of repeat rsvpers</p></dd>
+  
+    <dt class="align-right bold" title="rsvps_per_event_max"><span class="">rsvps_per_event_max</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: Maximum range of the average number of RSVPs per event</p></dd>
+  
+    <dt class="align-right bold" title="rsvps_per_event_min"><span class="">rsvps_per_event_min</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: Minumum range of the average number of RSVPs per event</p></dd>
+  
+    <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+    <dd class="rounded-all"><p>List of Integers: the ids of topic of the group</p></dd>
+  
+    <dt class="align-right bold" title="upcoming_events_max"><span class="">upcoming_events_max</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: Maximum range of the number of the upcoming events</p></dd>
+  
+    <dt class="align-right bold" title="upcoming_events_min"><span class="">upcoming_events_min</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: Minumum range of the number of the upcoming events</p></dd>
+  
+    <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+    <dd class="rounded-all"><p>String: Zip code</p></dd>
+  
+  </dl>
+  
+  <h4 id="ordering">Ordering</h4>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold"><span class="">average_age</span></dt>
+    <dd class="rounded-all"><p>By the average age of members</p></dd>
+  
+    <dt class="align-right bold"><span class="">founded_date</span></dt>
+    <dd class="rounded-all"><p>By the founded date of the group</p></dd>
+  
+    <dt class="align-right bold"><span class="">gender_female</span></dt>
+    <dd class="rounded-all"><p>By the proportion of people who identify themselves as female</p></dd>
+  
+    <dt class="align-right bold"><span class="">gender_male</span></dt>
+    <dd class="rounded-all"><p>By the proportion of people who identify themselves as male</p></dd>
+  
+    <dt class="align-right bold"><span class="">gender_other</span></dt>
+    <dd class="rounded-all"><p>By the proportion of people who identify themselves as gender other than female or male</p></dd>
+  
+    <dt class="align-right bold"><span class="">gender_unknown</span></dt>
+    <dd class="rounded-all"><p>By the proportion of people whose gender info is unknown</p></dd>
+  
+    <dt class="align-right bold"><span class="">last_event</span></dt>
+    <dd class="rounded-all"><p>By the date of the last event happened</p></dd>
+  
+    <dt class="align-right bold"><span class="">member_count</span></dt>
+    <dd class="rounded-all"><p>By the number of members</p></dd>
+  
+    <dt class="align-right bold"><span class="">name</span></dt>
+    <dd class="rounded-all"><p>By the name of the groups</p></dd>
+  
+    <dt class="align-right bold"><span class="">next_event</span></dt>
+    <dd class="rounded-all"><p>By the date of the next event scheduled</p></dd>
+  
+    <dt class="align-right bold"><span class="">past_events</span></dt>
+    <dd class="rounded-all"><p>By the number of past meetups held</p></dd>
+  
+    <dt class="align-right bold"><span class="">past_rsvps</span></dt>
+    <dd class="rounded-all"><p>By the total number of past RSVPs</p></dd>
+  
+    <dt class="align-right bold"><span class="">pro_join_date</span></dt>
+    <dd class="rounded-all"><p>By the date the group joined the Pro org</p></dd>
+  
+    <dt class="align-right bold"><span class="">repeat_rsvpers</span></dt>
+    <dd class="rounded-all"><p>By the number of members RSVPing subsequent events</p></dd>
+  
+    <dt class="align-right bold"><span class="">rsvps_per_event</span></dt>
+    <dd class="rounded-all"><p>By the average number of RSVPs per event</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="average_age"><span class="">average_age</span></dt>
+    <dd class="rounded-all">
+    <p>Average age of the group members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="category"><span class="">category</span></dt>
+    <dd class="rounded-all">
+    <p>Categories that the group belongs to</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Id of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>Abbreviated name of the category</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="founded_date"><span class="">founded_date</span></dt>
+    <dd class="rounded-all">
+    <p>Date when the group was founded</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="gender_female"><span class="">gender_female</span></dt>
+    <dd class="rounded-all">
+    <p>Proportion of members who identify as female</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="gender_male"><span class="">gender_male</span></dt>
+    <dd class="rounded-all">
+    <p>Proportion of members who identify as male</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="gender_other"><span class="">gender_other</span></dt>
+    <dd class="rounded-all">
+    <p>Proportion of members who identify as gender other than male or female</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="gender_unknown"><span class="">gender_unknown</span></dt>
+    <dd class="rounded-all">
+    <p>Proportion of members whose gender is unknown</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Id of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="last_event"><span class="">last_event</span></dt>
+    <dd class="rounded-all">
+    <p>Date of the last meetup event, not present if the group never had a meetup event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Latitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Longitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_count"><span class="">member_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of the group members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="next_event"><span class="">next_event</span></dt>
+    <dd class="rounded-all">
+    <p>Date of the next meetup event, not present if the group has no event scheduled</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="past_events"><span class="">past_events</span></dt>
+    <dd class="rounded-all">
+    <p>Number of the past meetup events</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="past_rsvps"><span class="">past_rsvps</span></dt>
+    <dd class="rounded-all">
+    <p>Number of total RSVPs in the past</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="pro_join_date"><span class="">pro_join_date</span></dt>
+    <dd class="rounded-all">
+    <p>Date when the group joined the Pro organization</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="repeat_rsvpers"><span class="">repeat_rsvpers</span></dt>
+    <dd class="rounded-all">
+    <p>Number of members who RSVPed to a past event and RSVPs to a new event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvps_per_event"><span class="">rsvps_per_event</span></dt>
+    <dd class="rounded-all">
+    <p>Average number of RSVPs per event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State of the group, if in US or Canada</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>Status of the group, one of Active | Delisted | Inactive</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+    <dd class="rounded-all">
+    <p>Topics that are assigned to the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Id of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+       <dd class="rounded-all">
+        <p>Locale of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+       <dd class="rounded-all">
+        <p>Urlkey used to identify the topic on meetup.com</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="upcoming_events"><span class="">upcoming_events</span></dt>
+    <dd class="rounded-all">
+    <p>Number of the upcoming meetup events</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+    <dd class="rounded-all">
+    <p>Urlname used to identify the group on meetup.com</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_pro_:urlname_members.html
+++ b/test/data/_pro_:urlname_members.html
@@ -1,0 +1,244 @@
+
+        
+
+<div id="">
+  <h2>Search Pro Members</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /pro/:urlname/members
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Name, location, and time based search for the members of the meetups belonging to Pro organization.</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/pro/:urlname/members">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>All parameters are optional.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="active_within_days"><span class="">active_within_days</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: The range of date from the past until today, for the recent activity</p></dd>
+  
+    <dt class="align-right bold" title="chapters"><span class="">chapters</span></dt>
+    <dd class="rounded-all"><p>List of Integers: The chapters which the member belongs to</p></dd>
+  
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all"><p>String: Country</p></dd>
+  
+    <dt class="align-right bold" title="desc"><span class="">desc</span></dt>
+    <dd class="rounded-all"><p>Boolean: whether to sort ascending or decending</p></dd>
+  
+    <dt class="align-right bold" title="email_received"><span class="">email_received</span></dt>
+    <dd class="rounded-all"><p>Integers: The id of a previous emails that the member received</p></dd>
+  
+    <dt class="align-right bold" title="events_attended_max"><span class="">events_attended_max</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: Maximum number of attended events</p></dd>
+  
+    <dt class="align-right bold" title="events_attended_min"><span class="">events_attended_min</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: Minimum number of attended events</p></dd>
+  
+    <dt class="align-right bold" title="is_organizer"><span class="">is_organizer</span></dt>
+    <dd class="rounded-all"><p>Boolean: To limit to only organizers or non-organizers</p></dd>
+  
+    <dt class="align-right bold" title="join_time_max"><span class="">join_time_max</span></dt>
+    <dd class="rounded-all"><p>Milliseconds since epoch: The latest time limit for member join</p></dd>
+  
+    <dt class="align-right bold" title="join_time_min"><span class="">join_time_min</span></dt>
+    <dd class="rounded-all"><p>Milliseconds since epoch: The oldest time limit for member join</p></dd>
+  
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all"><p>Float: Latitude</p></dd>
+  
+    <dt class="align-right bold" title="location"><span class="">location</span></dt>
+    <dd class="rounded-all"><p>String: Raw location</p></dd>
+  
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all"><p>Float: Longitude</p></dd>
+  
+    <dt class="align-right bold" title="member_name"><span class="">member_name</span></dt>
+    <dd class="rounded-all"><p>String: Name of the member</p></dd>
+  
+    <dt class="align-right bold" title="offset"><span class="">offset</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: the page offset</p></dd>
+  
+    <dt class="align-right bold" title="order"><span class="">order</span></dt>
+    <dd class="rounded-all"><p>String: attribute to sort on</p></dd>
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>Positive Integer: the size of page window</p></dd>
+  
+    <dt class="align-right bold" title="query"><span class="">query</span></dt>
+    <dd class="rounded-all"><p>String: raw query string to search from member name or city</p></dd>
+  
+    <dt class="align-right bold" title="radius"><span class="">radius</span></dt>
+    <dd class="rounded-all"><p>String: <code>global</code>, <code>smart</code>, or search radius in Float</p></dd>
+  
+    <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+    <dd class="rounded-all"><p>String: Zip code</p></dd>
+  
+  </dl>
+  
+  <h4 id="ordering">Ordering</h4>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold"><span class="">events_attended</span></dt>
+    <dd class="rounded-all"><p>By the number of events attended</p></dd>
+  
+    <dt class="align-right bold"><span class="">is_organizer</span></dt>
+    <dd class="rounded-all"><p>By whether the member is an organizer or not</p></dd>
+  
+    <dt class="align-right bold"><span class="">join_time</span></dt>
+    <dd class="rounded-all"><p>By the time when the member joined Meetup</p></dd>
+  
+    <dt class="align-right bold"><span class="">last_access_time</span></dt>
+    <dd class="rounded-all"><p>By the time of most recent visit</p></dd>
+  
+    <dt class="align-right bold"><span class="">member_name</span></dt>
+    <dd class="rounded-all"><p>By the member name</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="chapters"><span class="">chapters</span></dt>
+    <dd class="rounded-all">
+    <p>Pro organization groups that the member belongs to</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Id of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country of the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="email"><span class="">email</span></dt>
+    <dd class="rounded-all">
+    <p>Email address of the member if the member opted to share it with the organization</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="events_attended"><span class="">events_attended</span></dt>
+    <dd class="rounded-all">
+    <p>The number of attended events</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_organizer"><span class="">is_organizer</span></dt>
+    <dd class="rounded-all">
+    <p>Organizer status of the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_time"><span class="">join_time</span></dt>
+    <dd class="rounded-all">
+    <p>The time when the member joined Meetup</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="last_access_time"><span class="">last_access_time</span></dt>
+    <dd class="rounded-all">
+    <p>The time when the last activity occured</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Latitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Longitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_id"><span class="">member_id</span></dt>
+    <dd class="rounded-all">
+    <p>Id of the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_name"><span class="">member_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_thumb_url"><span class="">photo_thumb_url</span></dt>
+    <dd class="rounded-all">
+    <p>Url of the photo thumbnail of the member</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State of the member, if in US or Canada</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_pro_:urlname_rsvps.html
+++ b/test/data/_pro_:urlname_rsvps.html
@@ -1,0 +1,100 @@
+
+        
+
+<div id="">
+  <h2>Get Pro Network RSVPs</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /pro/:urlname/rsvps
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Get the list of RSVP responses for the events across the entire Pro network</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/pro/:urlname/rsvps">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="offset"><span class="">offset</span></dt>
+    <dd class="rounded-all"><p>Integer: offset of page, starting from 0</p></dd>
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>Integer: size of page. Minimum of 1 and maximum of 200</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>if successful, 200 with the JSON array, ordered by mtime, recent first</p>
+  <dl>
+   
+    <dt class="align-right bold" title="event_id"><span class="">event_id</span></dt>
+    <dd class="rounded-all">
+    <p>Integer: Unique identifier for the event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_id"><span class="">group_id</span></dt>
+    <dd class="rounded-all">
+    <p>Integer: Unique identifier for the group for the event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_id"><span class="">member_id</span></dt>
+    <dd class="rounded-all">
+    <p>Integer: Unique identifier for the member who RSVPed</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="mtime"><span class="">mtime</span></dt>
+    <dd class="rounded-all">
+    <p>Long Integer: Unix timestamp of the last time RSVP response was modified</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_id"><span class="">rsvp_id</span></dt>
+    <dd class="rounded-all">
+    <p>Integer: Unique identifier for the rsvp response</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>String: Status of the RSVP response. One of <code>yes</code>, <code>no</code>, and <code>waitlisted</code></p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_pro_:urlname_rsvps_survey.html
+++ b/test/data/_pro_:urlname_rsvps_survey.html
@@ -1,0 +1,123 @@
+
+        
+
+<div id="">
+  <h2>Get Pro RSVP registration responses</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /pro/:urlname/rsvps/survey
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Get the list of RSVP registration responses for the events across the entire Pro network</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/pro/:urlname/rsvps/survey">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="cursor"><span class="">cursor</span></dt>
+    <dd class="rounded-all"><p>String: identifier for the next result page</p></dd>
+  
+    <dt class="align-right bold" title="events"><span class="">events</span></dt>
+    <dd class="rounded-all"><p>String: Comma separated list of event id. Max: 99 items</p></dd>
+  
+    <dt class="align-right bold" title="size"><span class="">size</span></dt>
+    <dd class="rounded-all"><p>Integer: amount of results for one request. Max: 1000 items</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="cursor"><span class="">cursor</span></dt>
+    <dd class="rounded-all">
+    <p>Identifier for next result page</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="results"><span class="">results</span></dt>
+    <dd class="rounded-all">
+    <p>List of registration responses</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+       <dd class="rounded-all">
+        <p>List of answers to event survey questions asked when the member RSVP'd in the order asked, only available to organizers and assistant organizers</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Translated question title</p></dd>
+            
+            <dt class="align-right bold" title="response"><span class="">response</span></dt>
+            <dd class="rounded-all"><p>Answer</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="chapterName"><span class="">chapterName</span></dt>
+       <dd class="rounded-all">
+        <p>Group name</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="email"><span class="">email</span></dt>
+       <dd class="rounded-all">
+        <p>Member email</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="eventTitle"><span class="">eventTitle</span></dt>
+       <dd class="rounded-all">
+        <p>Event title</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="updatedAt"><span class="">updatedAt</span></dt>
+       <dd class="rounded-all">
+        <p>Timestamp when registration was updated</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_pro_:urlname_tickets.html
+++ b/test/data/_pro_:urlname_tickets.html
@@ -1,0 +1,170 @@
+
+        
+
+<div id="">
+  <h2>Search Issued Pro Tickets</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /pro/:urlname/tickets
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Redeemed chapter, redeemed member, status, and timestamp for tickets belonging to Pro organization.</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/pro/:urlname/tickets">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>All parameters are optional.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="chapter_name"><span class="">chapter_name</span></dt>
+    <dd class="rounded-all"><p>String: partial or full name of the redeemed chapter</p></dd>
+  
+    <dt class="align-right bold" title="chapters"><span class="">chapters</span></dt>
+    <dd class="rounded-all"><p>Comma delimited positive integers: ids of redeemed chapters</p></dd>
+  
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all"><p>String: two-letter country code of the redeemed chapters</p></dd>
+  
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all"><p>Comma delimited strings: ticket status, among the following: inactive, available, claimed, redeemed</p></dd>
+  
+    <dt class="align-right bold" title="ticket_key"><span class="">ticket_key</span></dt>
+    <dd class="rounded-all"><p>String: full matching string of an issued ticket key</p></dd>
+  
+  </dl>
+  
+  <h4 id="ordering">Ordering</h4>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold"><span class="">chapter_name</span></dt>
+    <dd class="rounded-all"><p>By the name of the chapter that redeemed the ticket</p></dd>
+  
+    <dt class="align-right bold"><span class="">created</span></dt>
+    <dd class="rounded-all"><p>By the creation timestamp of ticket</p></dd>
+  
+    <dt class="align-right bold"><span class="">status</span></dt>
+    <dd class="rounded-all"><p>By the redeemed status of the ticket</p></dd>
+  
+    <dt class="align-right bold"><span class="">updated</span></dt>
+    <dd class="rounded-all"><p>By the update timestamp of ticket</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="chapter"><span class="">chapter</span></dt>
+    <dd class="rounded-all">
+    <p>Pro organization chapter that redeemed the ticket, if the ticket is redeemed</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country of the Chapter</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Id of the chapter</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the chapter</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the chapter on meetup.com</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Ticket creation time</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member"><span class="">member</span></dt>
+    <dd class="rounded-all">
+    <p>Member who claimed the ticket, if the ticket is claimed</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Id of the member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the member</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>The status of ticket, one of the following: inactive, available, claimed, redeemed</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="ticket_key"><span class="">ticket_key</span></dt>
+    <dd class="rounded-all">
+    <p>Ticket key</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Last update time of ticket</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_recommended_group_topics.html
+++ b/test/data/_recommended_group_topics.html
@@ -1,0 +1,115 @@
+
+        
+
+<div id="">
+  <h2>Recommend Group Topics</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /recommended/group_topics
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Recommends suggestions for group topics based on a text search or other topics</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/recommended/group_topics">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="exclude_topics"><span class="">exclude_topics</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of topic ids to exclude from the recommendations</p></dd>
+  
+    <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+    <dd class="rounded-all"><p>Defines a language preference for ordering results. Valid values are en-USen-AUde-DEeses-ESfr-FRit-ITpt-BRja-JPnl-NLko-KRpl-PLth-THtr-TRru-RUsv-SEpt-brpl-plit-itsv-seja-jpen-auru-rude-deen-usth-thtr-tres-esnl-nlfr-frko-krendefritptjanlkoplthtrrusv. You may also substitute this with the Accept-Language header</p></dd>
+  
+    <dt class="align-right bold" title="other_topics"><span class="">other_topics</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of topic ids to inform recommendations</p></dd>
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>Target number of recommendations to return. Defaults to 36.</p></dd>
+  
+    <dt class="align-right bold" title="text"><span class="">text</span></dt>
+    <dd class="rounded-all"><p>Free form text search</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>Returns list of topic object</p>
+  <dl>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>The description of the topic</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_count"><span class="">group_count</span></dt>
+    <dd class="rounded-all">
+    <p>The number of groups using this topic</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric topic id</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+    <dd class="rounded-all">
+    <p>Language topic originates from</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_count"><span class="">member_count</span></dt>
+    <dd class="rounded-all">
+    <p>The number of members interested in this topic</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Display name of the topic</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+    <dd class="rounded-all">
+    <p>The unique keyword used to identify this topic</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_recommended_groups.html
+++ b/test/data/_recommended_groups.html
@@ -1,0 +1,1272 @@
+
+        
+
+<div id="">
+  <h2>Recommended Groups</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /recommended/groups
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Returns groups Meetup finds relevant to you</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/recommended/groups">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>All parameters are optional. You may change the 'location' and 'radius' for the request. If you do not supply a location your request will be based on your IP's geographic location. If the server is unable to produce recommendations in a suitable amount of time, a 503 error will be returned.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="category"><span class="">category</span></dt>
+    <dd class="rounded-all"><p>A valid category id which limits recommended groups to a particular category</p></dd>
+  
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all"><p>A valid two character country code, defaults to US</p></dd>
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>Request that additional fields (separated by commas) be included in the output.</p></dd>
+  
+    <dt class="align-right bold" title="instant_join_only"><span class="">instant_join_only</span></dt>
+    <dd class="rounded-all"><p>Recommend only groups without join requirements and that can be joined instantly</p></dd>
+  
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all"><p>Approximate latitude</p></dd>
+  
+    <dt class="align-right bold" title="location"><span class="">location</span></dt>
+    <dd class="rounded-all"><p>Raw text location query</p></dd>
+  
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all"><p>Approximate longitude</p></dd>
+  
+    <dt class="align-right bold" title="radius"><span class="">radius</span></dt>
+    <dd class="rounded-all"><p>Radius in miles. May be 0.0-100.0, 'global' or 'smart', a dynamic radius based on the number of active groups in the area. Defaults to member's preferred radius</p></dd>
+  
+    <dt class="align-right bold" title="sort"><span class="">sort</span></dt>
+    <dd class="rounded-all"><p>How to order the results. Valid values are "default" or "static".</p></dd>
+  
+    <dt class="align-right bold" title="topic_id"><span class="">topic_id</span></dt>
+    <dd class="rounded-all"><p>Comma delimited list of up to 100 topic ids to help inform recommendations</p></dd>
+  
+    <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+    <dd class="rounded-all"><p>Zip code you are searching for recommendations in</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="approved"><span class="">approved</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean indicator for whether this Group has been approved or not.
+New Groups are generally approved (or removed)
+soon after creation.
+Returned when the "fields" request parameter value includes
+"approved"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="category"><span class="">category</span></dt>
+    <dd class="rounded-all">
+    <p>The primary category of the group, if the group has one</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric category id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>String identifier of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name used for sorting</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city_link"><span class="">city_link</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, a URL for the group's city</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="contributions"><span class="">contributions</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field containing the contribution details of the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="enabled"><span class="">enabled</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean stating if contributions are enabled for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="potential"><span class="">potential</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean stating that potential contributions are enabled for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="reason"><span class="">reason</span></dt>
+       <dd class="rounded-all">
+        <p>The reason a member might consider contributing</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thanks"><span class="">thanks</span></dt>
+       <dd class="rounded-all">
+        <p>The 'thank you' message to be given when a contribution is made</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time the group was created in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>Short description of group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="discussion_preferences"><span class="">discussion_preferences</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field that contains preference and permission data for group discussions</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="draft_event_count"><span class="">draft_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of draft events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee_options"><span class="">fee_options</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, returns payment options for event ticketing</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currencies"><span class="">currencies</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable currencies for the payment method specified by type</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="code"><span class="">code</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="default"><span class="">default</span></dt>
+            <dd class="rounded-all"><p>A boolean set to true if the currency is the group's default currency, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="is_setup"><span class="">is_setup</span></dt>
+       <dd class="rounded-all">
+        <p>A boolean set to true if the payment method specified by 'type' is set up for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="setup_link"><span class="">setup_link</span></dt>
+       <dd class="rounded-all">
+        <p>The URL for setting up the payment method specified by 'type'. This is returned if the payment method specified by 'type' is not set up for the group and the member has the permission to set it up</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of Set(stripe, wepay, paypal, none, cash)</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Group photo</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric group ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_simplehtml"><span class="">is_simplehtml</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, 'true' when the group description has been saved in a simplified HTML format, 'false' otherwise.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_info"><span class="">join_info</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, lists any questions requested when joining and required fields</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="photo_req"><span class="">photo_req</span></dt>
+       <dd class="rounded-all">
+        <p>true if required, false otherwise</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="questions"><span class="">questions</span></dt>
+       <dd class="rounded-all">
+        <p>List of profile questions organizer would like new members to answer prior to joining</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the question</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>The text of the question</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="questions_req"><span class="">questions_req</span></dt>
+       <dd class="rounded-all">
+        <p>true if required, false otherwise</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+    <dd class="rounded-all">
+    <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Group primary photo</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+    <dd class="rounded-all">
+    <p>Lang of founder or coordinator</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="last_event"><span class="">last_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the last hosted event, if the group has one. Returned when the "fields" request parameter value contains "last_event"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Latitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="leader_limit"><span class="">leader_limit</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup leaders limit in group (4 leaders for the Basic Subscription), note this info available only for orgs and coorgs</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="leads"><span class="">leads</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the number of members on this group's leadership team. Returned when the "fields" request parameter value contains "leads"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to group on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="list_addr"><span class="">list_addr</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field returning list address prefix. List mail will be {list_addr}-list@meetup.com. Announce email will be {list_addr}-announce@meetup.com. You must be a member of the group to see this</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="list_mode"><span class="">list_mode</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the policy for who can post the group mailing list. Returned when the "fields" request parameter value contains "list_mode". Value may be one of "moderated", "off", "open", or "orgs_only"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+    <dd class="rounded-all">
+    <p>City/State or City/Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Longitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_cap"><span class="">member_cap</span></dt>
+    <dd class="rounded-all">
+    <p>Number representing the maximum number of active members this group can have if capped. Returned only when requested in the fields request parameter and the authenticated member has permission to approve members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_limit"><span class="">member_limit</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup members limit in group (now it's 50 members in the Basic Subscription)</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="members"><span class="">members</span></dt>
+    <dd class="rounded-all">
+    <p>Number of Meetup members in this group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, returns membership dues for group if any</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+       <dd class="rounded-all">
+        <p>Currency in which the fee is declared</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="dues_links"><span class="">dues_links</span></dt>
+       <dd class="rounded-all">
+        <p>Links to dues management and checkout pages.</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="checkout_url"><span class="">checkout_url</span></dt>
+            <dd class="rounded-all"><p>Dues checkout page URL</p></dd>
+            
+            <dt class="align-right bold" title="settings_url"><span class="">settings_url</span></dt>
+            <dd class="rounded-all"><p>(Organizers only) Dues settings page URL</p></dd>
+            
+            <dt class="align-right bold" title="start_url"><span class="">start_url</span></dt>
+            <dd class="rounded-all"><p>(Organizers only) Dues setup page URL</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric fee value</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee_desc"><span class="">fee_desc</span></dt>
+       <dd class="rounded-all">
+        <p>The interval at which dues must be paid. Possible values may include: "month", "year", "day", or "every other day"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="methods"><span class="">methods</span></dt>
+       <dd class="rounded-all">
+        <p>Methods of payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="amazon_payments"><span class="">amazon_payments</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Amazon Payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="credit_card"><span class="">credit_card</span></dt>
+            <dd class="rounded-all"><p>(Deprecated - use <code>wepay</code> or <code>stripe</code> instead) Boolean indicator that credit cards are accepted</p></dd>
+            
+            <dt class="align-right bold" title="other"><span class="">other</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that other forms of payment are accepted</p></dd>
+            
+            <dt class="align-right bold" title="paypal"><span class="">paypal</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Paypal payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="stripe"><span class="">stripe</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Stripe payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="wepay"><span class="">wepay</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Wepay payments are accepted</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="reasons"><span class="">reasons</span></dt>
+       <dd class="rounded-all">
+        <p>Array of reasons containing one or more of the following values compensate_organizer, cover_costs, encourage_engagement, improve_meetups, other, provide_supplies, reserve_fund</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="reasons_other"><span class="">reasons_other</span></dt>
+       <dd class="rounded-all">
+        <p>An additional reason if specified.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+       <dd class="rounded-all">
+        <p>Conditions for refunds</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="custom"><span class="">custom</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator of a custom refund policy</p></dd>
+            
+            <dt class="align-right bold" title="group_closes"><span class="">group_closes</span></dt>
+            <dd class="rounded-all"><p>refund applies when the group closes</p></dd>
+            
+            <dt class="align-right bold" title="member_banned"><span class="">member_banned</span></dt>
+            <dd class="rounded-all"><p>refund applies when the member is banned</p></dd>
+            
+            <dt class="align-right bold" title="member_leaves"><span class="">member_leaves</span></dt>
+            <dd class="rounded-all"><p>refund applies when member leaves the group</p></dd>
+            
+            <dt class="align-right bold" title="none"><span class="">none</span></dt>
+            <dd class="rounded-all"><p>indicates there is no refund policy</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="required"><span class="">required</span></dt>
+       <dd class="rounded-all">
+        <p>true if dues are required</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="required_to"><span class="">required_to</span></dt>
+       <dd class="rounded-all">
+        <p>If the dues are required this indicates what they are required for. Currently may only be 'join'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self_payment_required"><span class="">self_payment_required</span></dt>
+       <dd class="rounded-all">
+        <p>Returns true if the authorized user is prevented from participating in the group until a payment is made</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="trial_days"><span class="">trial_days</span></dt>
+       <dd class="rounded-all">
+        <p>When present, returns the number of days the group is offering a free trial period for to new members. When not present, this indicates that the group does not offer a trial membership period</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="meta_category"><span class="">meta_category</span></dt>
+    <dd class="rounded-all">
+    <p>The meta category of the group, if the group has one</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="best_topics"><span class="">best_topics</span></dt>
+       <dd class="rounded-all">
+        <p>Represents the best topic matches for this category, returned when the "fields"
+request parameter value includes "best_topics"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic id</p></dd>
+            
+            <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+            <dd class="rounded-all"><p>Language topic originates from</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic</p></dd>
+            
+            <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+            <dd class="rounded-all"><p>The unique keyword used to identify this topic</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="category_ids"><span class="">category_ids</span></dt>
+       <dd class="rounded-all">
+        <p>List of numeric category ids associated with this topic category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic-category id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic-category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Photo representing this category</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>Unique string identifier for this category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name used for sorting</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="next_event"><span class="">next_event</span></dt>
+    <dd class="rounded-all">
+    <p>The current ongoing or next upcoming event, if one is scheduled</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="nominated_member"><span class="">nominated_member</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns if the logged in member has been nominated to take over the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="organizer"><span class="">organizer</span></dt>
+    <dd class="rounded-all">
+    <p>Group's primary organizer</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Bio of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer photo, where defined</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="past_event_count"><span class="">past_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of past events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="pending_members"><span class="">pending_members</span></dt>
+    <dd class="rounded-all">
+    <p>Number representing the count of members pending organizer approval to join. Returned only when requested in the fields request parameter and the authenticated member has permission to approve members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+    <dd class="rounded-all">
+    <p>Color combination used generate group duotone</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+       <dd class="rounded-all">
+        <p>Composite color in hexidecimal format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+       <dd class="rounded-all">
+        <p>Dark color in hexidecimal format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+       <dd class="rounded-all">
+        <p>Light color in hexidecimal format</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photos"><span class="">photos</span></dt>
+    <dd class="rounded-all">
+    <p>A small set of photos from the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_description"><span class="">plain_text_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in plain text format. Returned when then "fields" request parameter value contains "plain_text_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_no_images_description"><span class="">plain_text_no_images_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in plain text format with no images. Returned when then "fields" request parameter value contains "plain_text_no_images_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="proposed_event_count"><span class="">proposed_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of proposed events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="score"><span class="">score</span></dt>
+    <dd class="rounded-all">
+    <p>A numeric value representing how the relevancy of the group in this search context</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, contains details specific to the authorized user in this Meetup Group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform, potentially "broadcast_message": the ability to broadcast messages to group members via the "announce" mailing list, "event_create": the ability to create new events, "event_draft": the ability to save new events as drafts, "role_assign": the ability to assign member roles, "edit": the ability to edit group settings, "member_approval": the ability to approve or decline member requests to join, or "subscription_upgrade": the ability to upgrade this group's subscription plan</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Member's membership dues if the group has membership dues</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="cancelled"><span class="">cancelled</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that membership dues were cancelled</p></dd>
+            
+            <dt class="align-right bold" title="exempt"><span class="">exempt</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that the member is exempt from payment.</p></dd>
+            
+            <dt class="align-right bold" title="paid_until"><span class="">paid_until</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns the time in milliseconds since the epoch that the member's next payment is due</p></dd>
+            
+            <dt class="align-right bold" title="period_status"><span class="">period_status</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns one of the following values grace paid pending unpaid</p></dd>
+            
+            <dt class="align-right bold" title="total_amount"><span class="">total_amount</span></dt>
+            <dd class="rounded-all"><p>Total amount paid</p></dd>
+            
+            <dt class="align-right bold" title="transaction_time"><span class="">transaction_time</span></dt>
+            <dd class="rounded-all"><p>Time the transaction was made in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="trial"><span class="">trial</span></dt>
+            <dd class="rounded-all"><p>If the group offers a trial membership, this indicates information for unpaid members.</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="previous_membership_dues"><span class="">previous_membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Member's membership dues history when currently not a part of group i.e Status=none if the group has membership dues</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="cancelled"><span class="">cancelled</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that membership dues were cancelled</p></dd>
+            
+            <dt class="align-right bold" title="exempt"><span class="">exempt</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that the member is exempt from payment.</p></dd>
+            
+            <dt class="align-right bold" title="paid_until"><span class="">paid_until</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns the time in milliseconds since the epoch that the member's next payment is due</p></dd>
+            
+            <dt class="align-right bold" title="period_status"><span class="">period_status</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns one of the following values grace paid pending unpaid</p></dd>
+            
+            <dt class="align-right bold" title="total_amount"><span class="">total_amount</span></dt>
+            <dd class="rounded-all"><p>Total amount paid</p></dd>
+            
+            <dt class="align-right bold" title="transaction_time"><span class="">transaction_time</span></dt>
+            <dd class="rounded-all"><p>Time the transaction was made in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="trial"><span class="">trial</span></dt>
+            <dd class="rounded-all"><p>If the group offers a trial membership, this indicates information for unpaid members.</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>Member's role in group, if any: Organizer, Assistant Organizer, Event Organizer, etc.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Indicates the authorized user's membership with this group. Value may be one of "none", "pending", "pending_payment", "active", or "blocked"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+       <dd class="rounded-all">
+        <p>Member's last visit to the group site, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, a shorted URL for the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="similar_groups"><span class="">similar_groups</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns up to 5 groups similar to this groups, best suited for the authenticated member when a single group is queried for. Note: this field is being deprecated in favor of making a separate request to /:urlname/similar_groups</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Id of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photos"><span class="">photos</span></dt>
+       <dd class="rounded-all">
+        <p>Optional fields parameter. A small set of photos from the group</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What this group calls it's members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="simple_html_description"><span class="">simple_html_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in simple HTML source format. If this group's description was saved in simple HTML format, the description field will be an HTML translation of this source. Returned when the "fields" request parameter value contains "simple_html_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State of the group, if in US or Canada</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>Status of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+    <dd class="rounded-all">
+    <p>This represents the universal timezone identifier for the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the group's topics</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+       <dd class="rounded-all">
+        <p>Language topic originates from</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+       <dd class="rounded-all">
+        <p>The unique keyword used to identify this topic</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="untranslated_city"><span class="">untranslated_city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group, not translated</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="upcoming_event_count"><span class="">upcoming_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of upcoming events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+    <dd class="rounded-all">
+    <p>Urlname used to identify the group on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Who can see this group. One of members, public or public_limited</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="welcome_message"><span class="">welcome_message</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the Group's default welcome message if the authenticated member is the organizer of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="who"><span class="">who</span></dt>
+    <dd class="rounded-all">
+    <p>What the group calls its members</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_recommended_groups_ignores_:urlname.html
+++ b/test/data/_recommended_groups_ignores_:urlname.html
@@ -1,0 +1,58 @@
+
+        
+
+<div id="">
+  <h2>Recommended Groups Ignore</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /recommended/groups/ignores/:urlname
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Provides a form of feedback by requesting to remove a group from future recommendations</p>
+  </div>
+  
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>Only the path parameter :urlname is required. You are limited to 100 of these requests in a 24 hour period of time.</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>A successful request will result in a 201 Created or 204 No Content response. If you go over the rate limit documented for this service you will receive a 429 Too Many Requests responses. Otherwise, a 400 Bad Request response is returned</p>
+  <dl>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_self_abuse_reports.html
+++ b/test/data/_self_abuse_reports.html
@@ -1,0 +1,80 @@
+
+        
+
+<div id="">
+  <h2>Report Abuse</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /self/abuse_reports
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">reporting</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Submits a new abuse report for a target member. Abuse reports will be followed up on by our Community Support team.</p>
+  </div>
+  
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>This method requires the oauth <code>reporting</code> scope for oauth-authenticated requests</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="comments"><span class="">comments</span></dt>
+    <dd class="rounded-all"><p>An optional string of text that describes why you are submitting this report</p></dd>
+  
+    <dt class="align-right bold" title="content_tag"><span class="">content_tag</span></dt>
+    <dd class="rounded-all"><p>An optional identifier for flagged content that identifies both the type and id, where possible, of the content reported. The type and id should be separated by a ':' character, e.g <code>event_comment:{event_comment_id}</code>. Valid content_tag types include conversation, conversation_message, convo, custom_list, email, event_comment, event_photo, group, mailing_list, member_photo, member_profile, message_board, pro_megaphone, reply, service_group_communication, service_group_communication_message. If member_id is not provided, content_tag should be provided to imply member_id</p></dd>
+  
+    <dt class="align-right bold" title="member_id"><span class="">member_id</span></dt>
+    <dd class="rounded-all"><p>A numeric identifier for the member being reported. If not provided, this will be infered by the author of the content associated with the provided <code>content_tag</code></p></dd>
+  
+    <dt class="align-right bold" title="type"><span class="param_required">type</span></dt>
+    <dd class="rounded-all"><p>A required identifier for type of abuse you are reporting. Acceptable values include general:underage, general:misrepresentation, general:sexually_explicit, general:hateful, general:violent, general:spam, general:intellectual_property, general:other, message:sexually_explicit, message:hateful, message:violent, message:misinformation, message:spam, message:other, photo:sexually_explicit, photo:hateful, photo:violent, photo:misleading_title, photo:intellectual_property, irl:misrepresentation, irl:hateful, irl:violent, irl:other, abuse, cron, dangerous, dislike_photo, fake, graphic_content, graphic_photo, impersonation, inappropriate, inappropriate_photo, join, licensed_services, offsite, not_accurate, not_irl, other, photo, sex, spam, transactional, underage, pay_dispute, nudity, violence, harmful_activities, not_community, promotion_focus</p></dd>
+  
+    <dt class="align-right bold" title="url"><span class="">url</span></dt>
+    <dd class="rounded-all"><p>An optional URL for the location of the reported content if one exists</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>A successful abuse report request will result in a 202 Accepted response</p>
+  <dl>
+  
+  </dl>
+  
+  
+  <h3 id="examples" class="rounded-all">Examples</h3>
+  <p>Submit an abuse report for member {member_id} for posting inappropriate comments</p>
+<pre><code>curl -H "Authorization: Bearer {token}" \
+  "https://api.meetup.com/self/abuse_reports" \
+  -d "member_id={member_id}&amp;type=inappropriate&amp;comment=This member has been posting inappropriate comments on my Meetups"
+</code></pre>
+  
+</div>
+
+
+      

--- a/test/data/_self_blocks_:member_id.html
+++ b/test/data/_self_blocks_:member_id.html
@@ -1,0 +1,188 @@
+
+        
+
+<div id="status">
+  <h2>Block status</h2>
+  <div id="statusuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /self/blocks/:member_id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">reporting</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Checks the block status for a target member relative to the authenticated member</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/self/blocks/:member_id">Try it in the console</a></p>
+  <h3 id="statusparams" class="rounded-all">Request Parameters</h3>
+  <div class="statusparam-notes"><p>A valid member_id path parameter for the target member is required.</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="statusresponse" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>The block status for the target member. This may be one of 'blocked' or 'none'</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+<div id="block">
+  <h2>Block member</h2>
+  <div id="blockuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">POST</strong> /self/blocks/:member_id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">reporting</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Blocks a target member from various interactions with the authenticated member on the platform</p>
+  </div>
+  
+  <h3 id="blockparams" class="rounded-all">Request Parameters</h3>
+  <div class="blockparam-notes"><p>A valid member_id path parameter for the target member is required. This method requires the oauth <code>reporting</code> scope for oauth-authenticated requests</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="comments"><span class="">comments</span></dt>
+    <dd class="rounded-all"><p>An optional string of text describing why you have chosen to block this member</p></dd>
+  
+    <dt class="align-right bold" title="report"><span class="">report</span></dt>
+    <dd class="rounded-all"><p>An optional value that represents a type of abuse the target member is being blocked for. Acceptable values include one of the following: fake, impersonation, inappropriate_photo, offsite, underage</p></dd>
+  
+  </dl>
+  
+  <h3 id="blockresponse" class="rounded-all">Response</h3>
+  <p>A successful block request will result in a 204 No Content response</p>
+  <dl>
+  
+  </dl>
+  
+  
+  <h3 id="blockexamples" class="rounded-all">Examples</h3>
+  <p>Block a member {member_id} as a member authorized with the token {token} and the scope "abuse"</p>
+<pre><code>curl -X POST -H "Authorization: Bearer {token}" \
+  "https://api.meetup.com/self/blocks/{member_id}"
+</code></pre>
+  
+</div>
+
+<div id="unblock">
+  <h2>Unblock member</h2>
+  <div id="unblockuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">DELETE</strong> /self/blocks/:member_id
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">reporting</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Unblocks a previously blocked member from various interactions with the authenticated member on the platform</p>
+  </div>
+  
+  <h3 id="unblockparams" class="rounded-all">Request Parameters</h3>
+  <div class="unblockparam-notes"><p>A valid member_id path parameter for the target member is required. This method requires the oauth <code>reporting</code> scope for oauth-authenticated requests.</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="unblockresponse" class="rounded-all">Response</h3>
+  <p>A successful unblock request will result in a 204 No Content response</p>
+  <dl>
+  
+  </dl>
+  
+  
+  <h3 id="unblockexamples" class="rounded-all">Examples</h3>
+  <p>Block a member {member_id} as a member authorized with the token {token} and scope "abuse"</p>
+<pre><code>curl -X DELETE -H "Authorization: Bearer {token}" \
+  "https://api.meetup.com/self/blocks/{member_id}"
+</code></pre>
+  
+</div>
+
+
+      

--- a/test/data/_self_calendar.html
+++ b/test/data/_self_calendar.html
@@ -1,0 +1,1329 @@
+
+        
+
+<div id="list">
+  <h2>Member Calendar</h2>
+  <div id="listuri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /self/calendar
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Get a listing of all upcoming Meetup events for the authenticated member</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/self/calendar">Try it in the console</a></p>
+  <h3 id="listparams" class="rounded-all">Request Parameters</h3>
+  <div class="listparam-notes"><p>All parameters are optional.</p>
+<p>This endpoint uses HTTP <a href="/meetup_api/docs/#v3_json">Link header based pagination</a></p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional fields names which may be appended to the response</p></dd>
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>Number of results to return in a page. Defaults to 200</p></dd>
+  
+  </dl>
+  
+  <h3 id="listresponse" class="rounded-all">Response</h3>
+  
+  <dl>
+   
+    <dt class="align-right bold" title="attendance_count"><span class="">attendance_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of all members marked as attended, yes RSVPs that were not changed by attendance and their guests</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="attendance_sample"><span class="">attendance_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection of members marked as attended and yes RSVPs that were not changed by attendance</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="attendee_sample"><span class="">attendee_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection of attendance records of members marked as attended and yes RSVPs that were not changed by attendance. For upcoming events, this represents collection of yes RSVPs</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="comment_count"><span class="">comment_count</span></dt>
+    <dd class="rounded-all">
+    <p>An aggregate count of all comments and replies for a given event, returned when fields request parameter value includes 'comment_count'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Creation time of the event, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+    <dd class="rounded-all">
+    <p>Is event date matches the series pattern</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the event in HTML. Email addresses and phone numbers will be masked for non-members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description_images"><span class="">description_images</span></dt>
+    <dd class="rounded-all">
+    <p>A list of image urls included in the event description.  returned when "fields" request parameter value contains "description_images, only supported for GET /event/:id currently"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+    <dd class="rounded-all">
+    <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="event_hosts"><span class="">event_hosts</span></dt>
+    <dd class="rounded-all">
+    <p>List of members hosting the event, returned when fields request parameter value includes 'event_hosts'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="host_count"><span class="">host_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of times member hosted for group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="intro"><span class="">intro</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's introduction</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_date"><span class="">join_date</span></dt>
+       <dd class="rounded-all">
+        <p>Group join date in milliseconds since epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's name</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo if one exists</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="featured"><span class="">featured</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean indicator of whether or not a given event is featured, returned when fields request parameter value includes 'featured'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="featured_photo"><span class="">featured_photo</span></dt>
+    <dd class="rounded-all">
+    <p>A featured photo for this event, returned when the 'fields' request paramater includes 'featured_photo'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+    <dd class="rounded-all">
+    <p>Ticketing fee information for events that support payments</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+       <dd class="rounded-all">
+        <p>Amount of the fee</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+       <dd class="rounded-all">
+        <p>Currency accepted for fee</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="description"><span class="">description</span></dt>
+       <dd class="rounded-all">
+        <p>Fee description, typically "per-person"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="label"><span class="">label</span></dt>
+       <dd class="rounded-all">
+        <p>Label for fee, typically "Price"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="required"><span class="">required</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean flag indicating if this fee is required to RSVP</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee_options"><span class="">fee_options</span></dt>
+    <dd class="rounded-all">
+    <p>Payment options for event ticketing, returned when the 'fields' request parameter value includes 'fee_options'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currencies"><span class="">currencies</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable currencies for the payment method specified by type</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="code"><span class="">code</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="default"><span class="">default</span></dt>
+            <dd class="rounded-all"><p>A boolean set to true if the currency is the group's default currency, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="is_setup"><span class="">is_setup</span></dt>
+       <dd class="rounded-all">
+        <p>A boolean set to true if the payment method specified by 'type' is set up for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="setup_link"><span class="">setup_link</span></dt>
+       <dd class="rounded-all">
+        <p>The URL for setting up the payment method specified by 'type'. This is returned if the payment method specified by 'type' is not set up for the group and the member has the permission to set it up</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of Set(stripe, wepay, paypal, none, cash)</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>Information about group hosting the event</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="category"><span class="">category</span></dt>
+       <dd class="rounded-all">
+        <p>Category group belongs to, returned when fields request parameter value includes 'group_category'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric category id</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the category</p></dd>
+            
+            <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+            <dd class="rounded-all"><p>String identifier of the category</p></dd>
+            
+            <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+            <dd class="rounded-all"><p>Name used for sorting</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric identifier for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_info"><span class="">join_info</span></dt>
+       <dd class="rounded-all">
+        <p>Lists any questions requested when joining and required fields. Returned with "fields" request parameter value includes "group_join_info"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="photo_req"><span class="">photo_req</span></dt>
+            <dd class="rounded-all"><p>true if required, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="questions"><span class="">questions</span></dt>
+            <dd class="rounded-all"><p>List of profile questions organizer would like new members to answer prior to joining</p></dd>
+            
+            <dt class="align-right bold" title="questions_req"><span class="">questions_req</span></dt>
+            <dd class="rounded-all"><p>true if required, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo, returned when fields request parameter value includes 'group_key_photo'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate group latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate group longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Membership dues information associated with hosting group, returned when fields request parameter value includes 'group_membership_dues'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency in which the fee is declared</p></dd>
+            
+            <dt class="align-right bold" title="dues_links"><span class="">dues_links</span></dt>
+            <dd class="rounded-all"><p>Links to dues management and checkout pages.</p></dd>
+            
+            <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+            <dd class="rounded-all"><p>Numeric fee value</p></dd>
+            
+            <dt class="align-right bold" title="fee_desc"><span class="">fee_desc</span></dt>
+            <dd class="rounded-all"><p>The interval at which dues must be paid. Possible values may include: "month", "year", "day", or "every other day"</p></dd>
+            
+            <dt class="align-right bold" title="methods"><span class="">methods</span></dt>
+            <dd class="rounded-all"><p>Methods of payments</p></dd>
+            
+            <dt class="align-right bold" title="reasons"><span class="">reasons</span></dt>
+            <dd class="rounded-all"><p>Array of reasons containing one or more of the following values compensate_organizer, cover_costs, encourage_engagement, improve_meetups, other, provide_supplies, reserve_fund</p></dd>
+            
+            <dt class="align-right bold" title="reasons_other"><span class="">reasons_other</span></dt>
+            <dd class="rounded-all"><p>An additional reason if specified.</p></dd>
+            
+            <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+            <dd class="rounded-all"><p>Conditions for refunds</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>true if dues are required</p></dd>
+            
+            <dt class="align-right bold" title="required_to"><span class="">required_to</span></dt>
+            <dd class="rounded-all"><p>If the dues are required this indicates what they are required for. Currently may only be 'join'</p></dd>
+            
+            <dt class="align-right bold" title="self_payment_required"><span class="">self_payment_required</span></dt>
+            <dd class="rounded-all"><p>Returns true if the authorized user is prevented from participating in the group until a payment is made</p></dd>
+            
+            <dt class="align-right bold" title="trial_days"><span class="">trial_days</span></dt>
+            <dd class="rounded-all"><p>When present, returns the number of days the group is offering a free trial period for to new members. When not present, this indicates that the group does not offer a trial membership period</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="meta_category"><span class="">meta_category</span></dt>
+       <dd class="rounded-all">
+        <p>The meta category of the group, if the group has one, returned when fields request parameter value inclues 'meta_category'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="best_topics"><span class="">best_topics</span></dt>
+            <dd class="rounded-all"><p>Represents the best topic matches for this category, returned when the "fields"
+request parameter value includes "best_topics"</p></dd>
+            
+            <dt class="align-right bold" title="category_ids"><span class="">category_ids</span></dt>
+            <dd class="rounded-all"><p>List of numeric category ids associated with this topic category</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic-category id</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic-category</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Photo representing this category</p></dd>
+            
+            <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+            <dd class="rounded-all"><p>Unique string identifier for this category</p></dd>
+            
+            <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+            <dd class="rounded-all"><p>Name used for sorting</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count"><span class="">past_event_count</span></dt>
+       <dd class="rounded-all">
+        <p>The number of past events belonging to the group, returned when "fields" includes "group_past_event_count"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Photo associated with group, returned when fields request parameter value includes 'group_photo'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used to generate group duotone, returned when fields request parameter value includes 'group_photo_gradient'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="pro_network"><span class="">pro_network</span></dt>
+       <dd class="rounded-all">
+        <p>Information on group's Pro organization, returned when "fields" request parameter value includes "group_pro_network"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="region"><span class="">region</span></dt>
+       <dd class="rounded-all">
+        <p>Language and region of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self"><span class="">self</span></dt>
+       <dd class="rounded-all">
+        <p>Information pertaining to the authenticated member with respect to the group, returned when fields request parameter value includes 'group_self_profile', 'group_self_actions', 'group_self_membership_dues', or 'group_self_status'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+            <dd class="rounded-all"><p>list of actions the authenticated member may perform, potentially "event_create": the ability to create new events, "event_draft": the ability to save new events as drafts, "role_assign": the ability to assign member roles, "edit": the ability to edit group settings, "member_approval": the ability to approve or decline member requests to join, or "subscription_upgrade": the ability to upgrade this group's subscription plan</p></dd>
+            
+            <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+            <dd class="rounded-all"><p>Membership dues information associated with hosting group, returned when "fields" request parameter value includes "group_membership_dues" and group has dues</p></dd>
+            
+            <dt class="align-right bold" title="profile"><span class="">profile</span></dt>
+            <dd class="rounded-all"><p>Profile of the authenticated member</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Indicates the authorized user's membership with this group.</p>
+<p>Value may be one of "none", "pending", "pending_payment", "active", or "blocked"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+       <dd class="rounded-all">
+        <p>Timezone of group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>Topics related to the group, returned when fields request parameter value includes 'group_topics'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic id</p></dd>
+            
+            <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+            <dd class="rounded-all"><p>Language topic originates from</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic</p></dd>
+            
+            <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+            <dd class="rounded-all"><p>The unique keyword used to identify this topic</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric urlname identifier for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+       <dd class="rounded-all">
+        <p>Group visibility, returned when fields request parameter value includes 'group_visibility'. Value may be "public", "public_limited", or "members".</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="how_to_find_us"><span class="">how_to_find_us</span></dt>
+    <dd class="rounded-all">
+    <p>Additional information on how to find members at a venue when provided by an organizer, returned when fields request parameter value includes 'how_to_find_us'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>A unique alphanumeric identifier for event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+    <dd class="rounded-all">
+    <p>Is event happening online</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to event on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+    <dd class="rounded-all">
+    <p>The local date of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+    <dd class="rounded-all">
+    <p>The local time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="manual_attendance_count"><span class="">manual_attendance_count</span></dt>
+    <dd class="rounded-all">
+    <p>Manually entered total attendee headcount, if any exists</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of the event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+    <dd class="rounded-all">
+    <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+    <dd class="rounded-all">
+    <p>Information about photo uploads for this event, returned when fields request parameter value includes 'photo_album'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="event"><span class="">event</span></dt>
+       <dd class="rounded-all">
+        <p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric event ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of event</p></dd>
+            
+            <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of no RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="time"><span class="">time</span></dt>
+            <dd class="rounded-all"><p>UTC start time of the event, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+            <dd class="rounded-all"><p>The local offset from UTC time, in milliseconds</p></dd>
+            
+            <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+            <dd class="rounded-all"><p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of yes RSVPs</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for photo album</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of photos uploaded</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection of photos uploaded for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Album title</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_description"><span class="">plain_text_description</span></dt>
+    <dd class="rounded-all">
+    <p>Plain text version of the event description. Email addresses and photo numbers will be masked for non-members. Returned when "fields" request parameter value contains "plain_text_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_no_images_description"><span class="">plain_text_no_images_description</span></dt>
+    <dd class="rounded-all">
+    <p>Plain text version of the event description without images. Email addresses and photo numbers will be masked for non-members. Returned when "fields" request parameter value contains "plain_text_no_images_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+    <dd class="rounded-all">
+    <p>The number of "yes" RSVPS an event has capacity for</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_rules"><span class="">rsvp_rules</span></dt>
+    <dd class="rounded-all">
+    <p>Information about conditions that allow for member RSVPs, returned when fields request parameter value include 'rsvp_rules'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="close_time"><span class="">close_time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC time that RSVPs will no longer be accepted, though organizers may close RSVPs earlier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="closed"><span class="">closed</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean value indicating whether or not RSVPing was explicitly closed for the event.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="guest_limit"><span class="">guest_limit</span></dt>
+       <dd class="rounded-all">
+        <p>Number of guests members may include in their RSVP, 0 or more</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="open_time"><span class="">open_time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC time that members may begin to RSVP</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+       <dd class="rounded-all">
+        <p>The organizer-defined terms for refunds. If this is defined, you must provide the authenticated member a way to access this information before they can RSVP. They will need to agree to these terms before they RSVP</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="days"><span class="">days</span></dt>
+            <dd class="rounded-all"><p>if member_cancellation is present, it's relative to this many days before the event</p></dd>
+            
+            <dt class="align-right bold" title="notes"><span class="">notes</span></dt>
+            <dd class="rounded-all"><p>additional refund policy notes</p></dd>
+            
+            <dt class="align-right bold" title="policies"><span class="">policies</span></dt>
+            <dd class="rounded-all"><p>list of one or more of the following. 'no_refunds' if the organizer will not issue refunds', 'member_cancellation' if the organizer offers a refund for member cancellation, 'event_cancellation' if the organizer offers a refund if the event is canceled, 'event_rescheduled' if the organizer offers a refund when the event is rescheduled</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlisting"><span class="">waitlisting</span></dt>
+       <dd class="rounded-all">
+        <p>Wait list handling when RSVP limit is reached. Value may be one of 'auto', 'manual' or 'off'</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection RSVPs for members attending this event, returned when fields request parameter value includes 'rsvp_sample'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the RSVP, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="member"><span class="">member</span></dt>
+       <dd class="rounded-all">
+        <p>Member who RSVP'd</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+            <dd class="rounded-all"><p>Intro of member</p></dd>
+            
+            <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+            <dd class="rounded-all"><p>Member's context within the event. Only returned in the context of an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric member ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of member</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="self"><span class="">self</span></dt>
+            <dd class="rounded-all"><p>Represents the authenticated member's relation to member.
+Returned with the "fields" request parameter includes "self" and
+the target member is not the authenticated member</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time of the RSVP, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvpable"><span class="">rsvpable</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean value indicating whether or not the authenticated member can RSVP or join the waitlist when the event is full.
+Returned when the "fields" request parameter value
+includes "rsvpable"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvpable_after_join"><span class="">rsvpable_after_join</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean value indicating whether or not the authenticated member can RSVP
+after joining the hosting group.
+Returned when the "fields" request parameter
+includes "rsvpable_after_join"
+and the authenticated member is <em>not</em> a member of the
+group hosting this event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="saved"><span class="">saved</span></dt>
+    <dd class="rounded-all">
+    <p>Whether the authorized member has saved the event, returned when fields request parameter value includes 'saved'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>represents details particular to the authorized user, only present if requested and authenticated member is a member of the hosting group, returned when fields request parameter value includes 'self'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform, potentially one or more of the following</p>
+<p>"announce" to announce the event to the group's members</p>
+<p>"attendance" to view or take attendance for the event</p>
+<p>"copy" the ability to copy an event</p>
+<p>"comment" the ability to post a comment or reply</p>
+<p>"payments" the ability to mark members as paid if the event is ticketed</p>
+<p>"publish" to publish a draft event</p>
+<p>"edit" to edit the event information</p>
+<p>"edit_hosts" to edit the hosts for the event</p>
+<p>"email_attendees" the ability to email event attendees</p>
+<p>"delete" to delete the event</p>
+<p>"rsvp" to RSVP yes or no to the event</p>
+<p>"wait" to get on the waiting list (using the same RSVP methods).</p>
+<p>"dues" if an organizer requires membership dues to RSVP and the authorized
+ member has not paid theirs</p>
+<p>"upload_photo" the ability to upload a photo for the event</p>
+<p>"cancel" the ability to cancel the event</p>
+<p>"close" the ability to close the RSVPs for the event</p>
+<p>"open" the ability to open the RSVPs for the event</p>
+<p>"invite" the ability to invite someone for the event</p>
+<p>"download_attendees" the ability to download the attendees list for the event</p>
+<p>"take_attendance" the ability to take attendance for the event</p>
+<p>"delete_cancelled" the ability to delete the event if it is cancelled</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="pay_status"><span class="">pay_status</span></dt>
+       <dd class="rounded-all">
+        <p>The authenticated member's payment status. This may be one of 'none', 'paid', 'partially_paid', 'payment_pending', 'echeck_pending', 'refund_pending', 'partially_refunded', 'refunded'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The authenticated member's role in within the group, if any. This may be one of: Organizer, Assistant Organizer, Event Organizer, etc.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp"><span class="">rsvp</span></dt>
+       <dd class="rounded-all">
+        <p>Member's RSVP, if any</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+            <dd class="rounded-all"><p>List of answers to event survey questions asked when the member RSVP'd in the order asked, only available to organizers and assistant organizers</p></dd>
+            
+            <dt class="align-right bold" title="guests"><span class="">guests</span></dt>
+            <dd class="rounded-all"><p>Number of guests the RSVP'd member will be bringing</p></dd>
+            
+            <dt class="align-right bold" title="response"><span class="">response</span></dt>
+            <dd class="rounded-all"><p>May be "yes" or "no".</p>
+<p>In cases where an event is over capacity and the member has shown an intent to attend,
+response may be "waitlist" if the event has a waitlist.</p>
+<p>In cases of ticketed events, this may be "yes_pending_payment"
+for a "yes" response for a ticketed event with an unprocessed payment</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="series"><span class="">series</span></dt>
+    <dd class="rounded-all">
+    <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="description"><span class="">description</span></dt>
+       <dd class="rounded-all">
+        <p>Human displayable description of how often events in this series occur</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+       <dd class="rounded-all">
+        <p>Date when this series ends/ended, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the series</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+       <dd class="rounded-all">
+        <p>Returned for events that are part of a monthly recurring series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="day_of_week"><span class="">day_of_week</span></dt>
+            <dd class="rounded-all"><p>Integer value between 1-7 (Monday-Sunday) for the day of week the recurrence occurs upon</p></dd>
+            
+            <dt class="align-right bold" title="interval"><span class="">interval</span></dt>
+            <dd class="rounded-all"><p>Integer number of months between each recurrence</p></dd>
+            
+            <dt class="align-right bold" title="week_of_month"><span class="">week_of_month</span></dt>
+            <dd class="rounded-all"><p>Integer value between 1-5 representing the week number on which the event recurs. A value of 5 indicates the event recurs on the last week of every month</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+       <dd class="rounded-all">
+        <p>Date when this series begins/began, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the template event of the series</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+       <dd class="rounded-all">
+        <p>Returned for events that are part of a weekly recurring series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="days_of_week"><span class="">days_of_week</span></dt>
+            <dd class="rounded-all"><p>List of integers 1-7 (Monday-Sunday) of days of week recurrence occurs upon</p></dd>
+            
+            <dt class="align-right bold" title="interval"><span class="">interval</span></dt>
+            <dd class="rounded-all"><p>Integer number of weeks between each recurrence</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>A shortened link for the event on meetup.com, returned when fields request parameter value includes "short_link"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="simple_html_description"><span class="">simple_html_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the event, in simple HTML source format. If this event's description was saved in simple HTML format, the description field will be an HTML translation of this source. Returned when the "fields"' request parameter contains "simple_html_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>"cancelled", "upcoming", "past", "proposed", "suggested", or "draft"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+    <dd class="rounded-all">
+    <p>List of organizer-defined survey questions intended to be asked of RSVPing members. Returned when the "fields"' request parameter contains "answers"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric question identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="question"><span class="">question</span></dt>
+       <dd class="rounded-all">
+        <p>Question text</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="time"><span class="">time</span></dt>
+    <dd class="rounded-all">
+    <p>UTC start time of the event, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Last modified time for the event in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The local offset from UTC time, in milliseconds</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+    <dd class="rounded-all">
+    <p>The event venue, present only if selected and not hidden by an organizer</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+       <dd class="rounded-all">
+        <p>Line 1 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+       <dd class="rounded-all">
+        <p>Line 2 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+       <dd class="rounded-all">
+        <p>Line 3 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="city"><span class="">city</span></dt>
+       <dd class="rounded-all">
+        <p>City of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country code of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric venue id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+       <dd class="rounded-all">
+        <p>The localized name of the venue's country</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Venue name</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+       <dd class="rounded-all">
+        <p>Phone number of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+       <dd class="rounded-all">
+        <p>true if the editor of the event altered the original venues pin location, false otherwise</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State of venue where available</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+       <dd class="rounded-all">
+        <p>ZIP code if, venue is in US or Canada</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="venue_visibility"><span class="">venue_visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Represents who can see the venue with a potential value of "members" or "public", returned when fields request parameter value includes "venue_visibility" and the authenticated member is a member of the group hosting the event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Event visibility: "public", "public_limited", or "members". Events in private groups that do not expose limited information are visible only to that group's members and should not be made public.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of members on the waitlist, if one exists</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="web_actions"><span class="">web_actions</span></dt>
+    <dd class="rounded-all">
+    <p>Set of "Invite" and google/yahoo/ical/outlook "Add to calendar" web actions</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="why"><span class="">why</span></dt>
+    <dd class="rounded-all">
+    <p>We should do this because...</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of yes RSVPs including guests</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_self_events.html
+++ b/test/data/_self_events.html
@@ -1,0 +1,1372 @@
+
+        
+
+<div id="">
+  <h2>Member Events</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /self/events
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Gets a listing of all scheduled Meetup Events the authenticated member has RSVP'd to
+that have been announced to the group.
+This listing is ordered from oldest to most recent by default</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/self/events">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>This endpoint uses HTTP <a href="/meetup_api/docs/#v3_json">Link header based pagination</a>. Clients may
+use the scroll request parameter to jump to a target scroll location.
+Valid values for scroll targets are defined below.
+A 'page' parameter may be provided to control the number of results returned.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="desc"><span class="">desc</span></dt>
+    <dd class="rounded-all"><p>When true, sorts results in descending order. Defaults to false</p></dd>
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional fields names which may be appended to the response</p></dd>
+  
+    <dt class="align-right bold" title="no_earlier_than"><span class="">no_earlier_than</span></dt>
+    <dd class="rounded-all"><p>An optional timestamp that represents a lower time bound (inclusive) for the start time of events in the local time of the group.
+If provided, it must be a string in ISO 8601 format without a time zone specified, i.e. 2018-06-01T00:00:00.000.
+If provided, the API will not return events with a start time earlier than the time specified by this parameter.
+If both this parameter and scroll are present, such that scroll does not have a type of ctime and it requests events
+that start after the specified scroll time,
+then the API returns events after whichever of scroll and no_earlier_than comes later.</p></dd>
+  
+    <dt class="align-right bold" title="no_later_than"><span class="">no_later_than</span></dt>
+    <dd class="rounded-all"><p>An optional timestamp that represents an upper time bound (exclusive) for the start time of events in the local time of the group.
+If provided, it must be a string in ISO 8601 format without a time zone specified, i.e. 2018-06-01T00:00:00.000.
+If provided, the API will not return events with a start time later than or equal to the time specified by this parameter.
+If both this parameter and scroll are present, such that scroll does not have a type of ctime and it
+requests events before the specified scroll time,
+then the API returns events before whichever of scroll and no_later_than comes earlier.</p></dd>
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>Number of results to return. Defaults to 200.</p></dd>
+  
+    <dt class="align-right bold" title="rsvp"><span class="">rsvp</span></dt>
+    <dd class="rounded-all"><p>Comma-delimited list of RSVP responses.
+Valid values are "waitlist" or "yes". The default is "yes"</p></dd>
+  
+    <dt class="align-right bold" title="scroll"><span class="">scroll</span></dt>
+    <dd class="rounded-all"><p>A string representing an alias for a point on a timeline.</p>
+<p>Supported values are as follows.</p>
+<p><strong>recent_past</strong>: Scroll to the last RSVP'd Meetup Event that has passed.
+ If there is no recent RSVP, this defaults to <strong>next_upcoming</strong></p>
+<p><strong>next_upcoming</strong>: Scroll to the next upcoming Meetup Event the authenticated member
+RSVP'd to.</p>
+<p>Alternatively the server may generate a scroll value used for pagination Link headers.
+Clients should treat the contents of those as a transparent string. Its
+contents are subject to change in the future</p></dd>
+  
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all"><p>Comma-delimited list of event statuses.
+Valid values are "past" or "upcoming"</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>Returns a list of Events the authenticated Member has RSVP'd in order of oldest to most recent</p>
+  <dl>
+   
+    <dt class="align-right bold" title="attendance_count"><span class="">attendance_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of all members marked as attended, yes RSVPs that were not changed by attendance and their guests</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="attendance_sample"><span class="">attendance_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection of members marked as attended and yes RSVPs that were not changed by attendance</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="attendee_sample"><span class="">attendee_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection of attendance records of members marked as attended and yes RSVPs that were not changed by attendance. For upcoming events, this represents collection of yes RSVPs</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="comment_count"><span class="">comment_count</span></dt>
+    <dd class="rounded-all">
+    <p>An aggregate count of all comments and replies for a given event, returned when fields request parameter value includes 'comment_count'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Creation time of the event, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="date_in_series_pattern"><span class="">date_in_series_pattern</span></dt>
+    <dd class="rounded-all">
+    <p>Is event date matches the series pattern</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the event in HTML. Email addresses and phone numbers will be masked for non-members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description_images"><span class="">description_images</span></dt>
+    <dd class="rounded-all">
+    <p>A list of image urls included in the event description.  returned when "fields" request parameter value contains "description_images, only supported for GET /event/:id currently"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="duration"><span class="">duration</span></dt>
+    <dd class="rounded-all">
+    <p>Scheduled event duration in milliseconds, if an end time is specified by the organizer. When not present, a default of 3 hours may be assumed by applications</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="event_hosts"><span class="">event_hosts</span></dt>
+    <dd class="rounded-all">
+    <p>List of members hosting the event, returned when fields request parameter value includes 'event_hosts'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="host_count"><span class="">host_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of times member hosted for group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="intro"><span class="">intro</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's introduction</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_date"><span class="">join_date</span></dt>
+       <dd class="rounded-all">
+        <p>Group join date in milliseconds since epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Host member's name</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Member photo if one exists</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="featured"><span class="">featured</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean indicator of whether or not a given event is featured, returned when fields request parameter value includes 'featured'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="featured_photo"><span class="">featured_photo</span></dt>
+    <dd class="rounded-all">
+    <p>A featured photo for this event, returned when the 'fields' request paramater includes 'featured_photo'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+    <dd class="rounded-all">
+    <p>Ticketing fee information for events that support payments</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="accepts"><span class="">accepts</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of "paypal", "wepay", "stripe", or "cash"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="amount"><span class="">amount</span></dt>
+       <dd class="rounded-all">
+        <p>Amount of the fee</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+       <dd class="rounded-all">
+        <p>Currency accepted for fee</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="description"><span class="">description</span></dt>
+       <dd class="rounded-all">
+        <p>Fee description, typically "per-person"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="label"><span class="">label</span></dt>
+       <dd class="rounded-all">
+        <p>Label for fee, typically "Price"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="required"><span class="">required</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean flag indicating if this fee is required to RSVP</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee_options"><span class="">fee_options</span></dt>
+    <dd class="rounded-all">
+    <p>Payment options for event ticketing, returned when the 'fields' request parameter value includes 'fee_options'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currencies"><span class="">currencies</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable currencies for the payment method specified by type</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="code"><span class="">code</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="default"><span class="">default</span></dt>
+            <dd class="rounded-all"><p>A boolean set to true if the currency is the group's default currency, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="is_setup"><span class="">is_setup</span></dt>
+       <dd class="rounded-all">
+        <p>A boolean set to true if the payment method specified by 'type' is set up for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="setup_link"><span class="">setup_link</span></dt>
+       <dd class="rounded-all">
+        <p>The URL for setting up the payment method specified by 'type'. This is returned if the payment method specified by 'type' is not set up for the group and the member has the permission to set it up</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of Set(stripe, wepay, paypal, none, cash)</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group"><span class="">group</span></dt>
+    <dd class="rounded-all">
+    <p>Information about group hosting the event</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="category"><span class="">category</span></dt>
+       <dd class="rounded-all">
+        <p>Category group belongs to, returned when fields request parameter value includes 'group_category'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric category id</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the category</p></dd>
+            
+            <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+            <dd class="rounded-all"><p>String identifier of the category</p></dd>
+            
+            <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+            <dd class="rounded-all"><p>Name used for sorting</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric identifier for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_info"><span class="">join_info</span></dt>
+       <dd class="rounded-all">
+        <p>Lists any questions requested when joining and required fields. Returned with "fields" request parameter value includes "group_join_info"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="photo_req"><span class="">photo_req</span></dt>
+            <dd class="rounded-all"><p>true if required, false otherwise</p></dd>
+            
+            <dt class="align-right bold" title="questions"><span class="">questions</span></dt>
+            <dd class="rounded-all"><p>List of profile questions organizer would like new members to answer prior to joining</p></dd>
+            
+            <dt class="align-right bold" title="questions_req"><span class="">questions_req</span></dt>
+            <dd class="rounded-all"><p>true if required, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Indicator of how new members may be able to join. be one of "open", "approval" or "closed"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+       <dd class="rounded-all">
+        <p>Group primary photo, returned when fields request parameter value includes 'group_key_photo'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate group latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+       <dd class="rounded-all">
+        <p>City/State or City/Country of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate group longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Membership dues information associated with hosting group, returned when fields request parameter value includes 'group_membership_dues'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+            <dd class="rounded-all"><p>Currency in which the fee is declared</p></dd>
+            
+            <dt class="align-right bold" title="dues_links"><span class="">dues_links</span></dt>
+            <dd class="rounded-all"><p>Links to dues management and checkout pages.</p></dd>
+            
+            <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+            <dd class="rounded-all"><p>Numeric fee value</p></dd>
+            
+            <dt class="align-right bold" title="fee_desc"><span class="">fee_desc</span></dt>
+            <dd class="rounded-all"><p>The interval at which dues must be paid. Possible values may include: "month", "year", "day", or "every other day"</p></dd>
+            
+            <dt class="align-right bold" title="methods"><span class="">methods</span></dt>
+            <dd class="rounded-all"><p>Methods of payments</p></dd>
+            
+            <dt class="align-right bold" title="reasons"><span class="">reasons</span></dt>
+            <dd class="rounded-all"><p>Array of reasons containing one or more of the following values compensate_organizer, cover_costs, encourage_engagement, improve_meetups, other, provide_supplies, reserve_fund</p></dd>
+            
+            <dt class="align-right bold" title="reasons_other"><span class="">reasons_other</span></dt>
+            <dd class="rounded-all"><p>An additional reason if specified.</p></dd>
+            
+            <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+            <dd class="rounded-all"><p>Conditions for refunds</p></dd>
+            
+            <dt class="align-right bold" title="required"><span class="">required</span></dt>
+            <dd class="rounded-all"><p>true if dues are required</p></dd>
+            
+            <dt class="align-right bold" title="required_to"><span class="">required_to</span></dt>
+            <dd class="rounded-all"><p>If the dues are required this indicates what they are required for. Currently may only be 'join'</p></dd>
+            
+            <dt class="align-right bold" title="self_payment_required"><span class="">self_payment_required</span></dt>
+            <dd class="rounded-all"><p>Returns true if the authorized user is prevented from participating in the group until a payment is made</p></dd>
+            
+            <dt class="align-right bold" title="trial_days"><span class="">trial_days</span></dt>
+            <dd class="rounded-all"><p>When present, returns the number of days the group is offering a free trial period for to new members. When not present, this indicates that the group does not offer a trial membership period</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="meta_category"><span class="">meta_category</span></dt>
+       <dd class="rounded-all">
+        <p>The meta category of the group, if the group has one, returned when fields request parameter value inclues 'meta_category'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="best_topics"><span class="">best_topics</span></dt>
+            <dd class="rounded-all"><p>Represents the best topic matches for this category, returned when the "fields"
+request parameter value includes "best_topics"</p></dd>
+            
+            <dt class="align-right bold" title="category_ids"><span class="">category_ids</span></dt>
+            <dd class="rounded-all"><p>List of numeric category ids associated with this topic category</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic-category id</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic-category</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Photo representing this category</p></dd>
+            
+            <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+            <dd class="rounded-all"><p>Unique string identifier for this category</p></dd>
+            
+            <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+            <dd class="rounded-all"><p>Name used for sorting</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="past_event_count"><span class="">past_event_count</span></dt>
+       <dd class="rounded-all">
+        <p>The number of past events belonging to the group, returned when "fields" includes "group_past_event_count"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Photo associated with group, returned when fields request parameter value includes 'group_photo'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+       <dd class="rounded-all">
+        <p>Color combination used to generate group duotone, returned when fields request parameter value includes 'group_photo_gradient'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+            <dd class="rounded-all"><p>Composite color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+            <dd class="rounded-all"><p>Dark color in hexidecimal format</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier</p></dd>
+            
+            <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+            <dd class="rounded-all"><p>Light color in hexidecimal format</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="pro_network"><span class="">pro_network</span></dt>
+       <dd class="rounded-all">
+        <p>Information on group's Pro organization, returned when "fields" request parameter value includes "group_pro_network"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="region"><span class="">region</span></dt>
+       <dd class="rounded-all">
+        <p>Language and region of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self"><span class="">self</span></dt>
+       <dd class="rounded-all">
+        <p>Information pertaining to the authenticated member with respect to the group, returned when fields request parameter value includes 'group_self_profile', 'group_self_actions', 'group_self_membership_dues', or 'group_self_status'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+            <dd class="rounded-all"><p>list of actions the authenticated member may perform, potentially "event_create": the ability to create new events, "event_draft": the ability to save new events as drafts, "role_assign": the ability to assign member roles, "edit": the ability to edit group settings, "member_approval": the ability to approve or decline member requests to join, or "subscription_upgrade": the ability to upgrade this group's subscription plan</p></dd>
+            
+            <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+            <dd class="rounded-all"><p>Membership dues information associated with hosting group, returned when "fields" request parameter value includes "group_membership_dues" and group has dues</p></dd>
+            
+            <dt class="align-right bold" title="profile"><span class="">profile</span></dt>
+            <dd class="rounded-all"><p>Profile of the authenticated member</p></dd>
+            
+            <dt class="align-right bold" title="status"><span class="">status</span></dt>
+            <dd class="rounded-all"><p>Indicates the authorized user's membership with this group.</p>
+<p>Value may be one of "none", "pending", "pending_payment", "active", or "blocked"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+       <dd class="rounded-all">
+        <p>Timezone of group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+       <dd class="rounded-all">
+        <p>Topics related to the group, returned when fields request parameter value includes 'group_topics'</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic id</p></dd>
+            
+            <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+            <dd class="rounded-all"><p>Language topic originates from</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic</p></dd>
+            
+            <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+            <dd class="rounded-all"><p>The unique keyword used to identify this topic</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric urlname identifier for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+       <dd class="rounded-all">
+        <p>Group visibility, returned when fields request parameter value includes 'group_visibility'. Value may be "public", "public_limited", or "members".</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What the group calls its members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="how_to_find_us"><span class="">how_to_find_us</span></dt>
+    <dd class="rounded-all">
+    <p>Additional information on how to find members at a venue when provided by an organizer, returned when fields request parameter value includes 'how_to_find_us'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>A unique alphanumeric identifier for event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_online_event"><span class="">is_online_event</span></dt>
+    <dd class="rounded-all">
+    <p>Is event happening online</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to event on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="local_date"><span class="">local_date</span></dt>
+    <dd class="rounded-all">
+    <p>The local date of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="local_time"><span class="">local_time</span></dt>
+    <dd class="rounded-all">
+    <p>The local time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="manual_attendance_count"><span class="">manual_attendance_count</span></dt>
+    <dd class="rounded-all">
+    <p>Manually entered total attendee headcount, if any exists</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of the event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="past_event_count_inclusive"><span class="">past_event_count_inclusive</span></dt>
+    <dd class="rounded-all">
+    <p>Number of past events that happened before and including this event. Returned when "fields" request parameter value contains "past_event_count_inclusive"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+    <dd class="rounded-all">
+    <p>Information about photo uploads for this event, returned when fields request parameter value includes 'photo_album'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="event"><span class="">event</span></dt>
+       <dd class="rounded-all">
+        <p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Alphanumeric event ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of event</p></dd>
+            
+            <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of no RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="time"><span class="">time</span></dt>
+            <dd class="rounded-all"><p>UTC start time of the event, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+            <dd class="rounded-all"><p>The local offset from UTC time, in milliseconds</p></dd>
+            
+            <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+            <dd class="rounded-all"><p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p></dd>
+            
+            <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+            <dd class="rounded-all"><p>Number of yes RSVPs</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for photo album</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of photos uploaded</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+       <dd class="rounded-all">
+        <p>A small collection of photos uploaded for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="title"><span class="">title</span></dt>
+       <dd class="rounded-all">
+        <p>Album title</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_description"><span class="">plain_text_description</span></dt>
+    <dd class="rounded-all">
+    <p>Plain text version of the event description. Email addresses and photo numbers will be masked for non-members. Returned when "fields" request parameter value contains "plain_text_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_no_images_description"><span class="">plain_text_no_images_description</span></dt>
+    <dd class="rounded-all">
+    <p>Plain text version of the event description without images. Email addresses and photo numbers will be masked for non-members. Returned when "fields" request parameter value contains "plain_text_no_images_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_close_offset"><span class="">rsvp_close_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The amount of time between when RSVPs close and the start time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_limit"><span class="">rsvp_limit</span></dt>
+    <dd class="rounded-all">
+    <p>The number of "yes" RSVPS an event has capacity for</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_open_offset"><span class="">rsvp_open_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The amount of time between when RSVPs open and the start time of the Meetup in ISO 8601 format</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_rules"><span class="">rsvp_rules</span></dt>
+    <dd class="rounded-all">
+    <p>Information about conditions that allow for member RSVPs, returned when fields request parameter value include 'rsvp_rules'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="close_time"><span class="">close_time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC time that RSVPs will no longer be accepted, though organizers may close RSVPs earlier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="closed"><span class="">closed</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean value indicating whether or not RSVPing was explicitly closed for the event.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="guest_limit"><span class="">guest_limit</span></dt>
+       <dd class="rounded-all">
+        <p>Number of guests members may include in their RSVP, 0 or more</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="open_time"><span class="">open_time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC time that members may begin to RSVP</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+       <dd class="rounded-all">
+        <p>The organizer-defined terms for refunds. If this is defined, you must provide the authenticated member a way to access this information before they can RSVP. They will need to agree to these terms before they RSVP</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="days"><span class="">days</span></dt>
+            <dd class="rounded-all"><p>if member_cancellation is present, it's relative to this many days before the event</p></dd>
+            
+            <dt class="align-right bold" title="notes"><span class="">notes</span></dt>
+            <dd class="rounded-all"><p>additional refund policy notes</p></dd>
+            
+            <dt class="align-right bold" title="policies"><span class="">policies</span></dt>
+            <dd class="rounded-all"><p>list of one or more of the following. 'no_refunds' if the organizer will not issue refunds', 'member_cancellation' if the organizer offers a refund for member cancellation, 'event_cancellation' if the organizer offers a refund if the event is canceled, 'event_rescheduled' if the organizer offers a refund when the event is rescheduled</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="waitlisting"><span class="">waitlisting</span></dt>
+       <dd class="rounded-all">
+        <p>Wait list handling when RSVP limit is reached. Value may be one of 'auto', 'manual' or 'off'</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvp_sample"><span class="">rsvp_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small collection RSVPs for members attending this event, returned when fields request parameter value includes 'rsvp_sample'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="created"><span class="">created</span></dt>
+       <dd class="rounded-all">
+        <p>Creation time of the RSVP, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the RSVP. May be -1 for events scheduled in the future</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="member"><span class="">member</span></dt>
+       <dd class="rounded-all">
+        <p>Member who RSVP'd</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+            <dd class="rounded-all"><p>Intro of member</p></dd>
+            
+            <dt class="align-right bold" title="event_context"><span class="">event_context</span></dt>
+            <dd class="rounded-all"><p>Member's context within the event. Only returned in the context of an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric member ID</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Name of member</p></dd>
+            
+            <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+            <dd class="rounded-all"><p>Member photo, if available.
+Members who registered via Facebook may not have highres photos</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The leadership role of this member within the group, if any.
+Value may be one of assistant_organizer, coorganizer, event_organizer, organizer</p></dd>
+            
+            <dt class="align-right bold" title="self"><span class="">self</span></dt>
+            <dd class="rounded-all"><p>Represents the authenticated member's relation to member.
+Returned with the "fields" request parameter includes "self" and
+the target member is not the authenticated member</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Organizer defined title of member. May be absent if not defined</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+       <dd class="rounded-all">
+        <p>Last modified time of the RSVP, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvpable"><span class="">rsvpable</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean value indicating whether or not the authenticated member can RSVP or join the waitlist when the event is full.
+Returned when the "fields" request parameter value
+includes "rsvpable"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="rsvpable_after_join"><span class="">rsvpable_after_join</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean value indicating whether or not the authenticated member can RSVP
+after joining the hosting group.
+Returned when the "fields" request parameter
+includes "rsvpable_after_join"
+and the authenticated member is <em>not</em> a member of the
+group hosting this event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="saved"><span class="">saved</span></dt>
+    <dd class="rounded-all">
+    <p>Whether the authorized member has saved the event, returned when fields request parameter value includes 'saved'</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>represents details particular to the authorized user, only present if requested and authenticated member is a member of the hosting group, returned when fields request parameter value includes 'self'</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform, potentially one or more of the following</p>
+<p>"announce" to announce the event to the group's members</p>
+<p>"attendance" to view or take attendance for the event</p>
+<p>"copy" the ability to copy an event</p>
+<p>"comment" the ability to post a comment or reply</p>
+<p>"payments" the ability to mark members as paid if the event is ticketed</p>
+<p>"publish" to publish a draft event</p>
+<p>"edit" to edit the event information</p>
+<p>"edit_hosts" to edit the hosts for the event</p>
+<p>"email_attendees" the ability to email event attendees</p>
+<p>"delete" to delete the event</p>
+<p>"rsvp" to RSVP yes or no to the event</p>
+<p>"wait" to get on the waiting list (using the same RSVP methods).</p>
+<p>"dues" if an organizer requires membership dues to RSVP and the authorized
+ member has not paid theirs</p>
+<p>"upload_photo" the ability to upload a photo for the event</p>
+<p>"cancel" the ability to cancel the event</p>
+<p>"close" the ability to close the RSVPs for the event</p>
+<p>"open" the ability to open the RSVPs for the event</p>
+<p>"invite" the ability to invite someone for the event</p>
+<p>"download_attendees" the ability to download the attendees list for the event</p>
+<p>"take_attendance" the ability to take attendance for the event</p>
+<p>"delete_cancelled" the ability to delete the event if it is cancelled</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="pay_status"><span class="">pay_status</span></dt>
+       <dd class="rounded-all">
+        <p>The authenticated member's payment status. This may be one of 'none', 'paid', 'partially_paid', 'payment_pending', 'echeck_pending', 'refund_pending', 'partially_refunded', 'refunded'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>The authenticated member's role in within the group, if any. This may be one of: Organizer, Assistant Organizer, Event Organizer, etc.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="rsvp"><span class="">rsvp</span></dt>
+       <dd class="rounded-all">
+        <p>Member's RSVP, if any</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="answers"><span class="">answers</span></dt>
+            <dd class="rounded-all"><p>List of answers to event survey questions asked when the member RSVP'd in the order asked, only available to organizers and assistant organizers</p></dd>
+            
+            <dt class="align-right bold" title="guests"><span class="">guests</span></dt>
+            <dd class="rounded-all"><p>Number of guests the RSVP'd member will be bringing</p></dd>
+            
+            <dt class="align-right bold" title="response"><span class="">response</span></dt>
+            <dd class="rounded-all"><p>May be "yes" or "no".</p>
+<p>In cases where an event is over capacity and the member has shown an intent to attend,
+response may be "waitlist" if the event has a waitlist.</p>
+<p>In cases of ticketed events, this may be "yes_pending_payment"
+for a "yes" response for a ticketed event with an unprocessed payment</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="series"><span class="">series</span></dt>
+    <dd class="rounded-all">
+    <p>Returned when the "fields" request parameter value includes "series" for events that are part of a series of events</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="description"><span class="">description</span></dt>
+       <dd class="rounded-all">
+        <p>Human displayable description of how often events in this series occur</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+       <dd class="rounded-all">
+        <p>Date when this series ends/ended, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the series</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+       <dd class="rounded-all">
+        <p>Returned for events that are part of a monthly recurring series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="day_of_week"><span class="">day_of_week</span></dt>
+            <dd class="rounded-all"><p>Integer value between 1-7 (Monday-Sunday) for the day of week the recurrence occurs upon</p></dd>
+            
+            <dt class="align-right bold" title="interval"><span class="">interval</span></dt>
+            <dd class="rounded-all"><p>Integer number of months between each recurrence</p></dd>
+            
+            <dt class="align-right bold" title="week_of_month"><span class="">week_of_month</span></dt>
+            <dd class="rounded-all"><p>Integer value between 1-5 representing the week number on which the event recurs. A value of 5 indicates the event recurs on the last week of every month</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+       <dd class="rounded-all">
+        <p>Date when this series begins/began, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier for the template event of the series</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+       <dd class="rounded-all">
+        <p>Returned for events that are part of a weekly recurring series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="days_of_week"><span class="">days_of_week</span></dt>
+            <dd class="rounded-all"><p>List of integers 1-7 (Monday-Sunday) of days of week recurrence occurs upon</p></dd>
+            
+            <dt class="align-right bold" title="interval"><span class="">interval</span></dt>
+            <dd class="rounded-all"><p>Integer number of weeks between each recurrence</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>A shortened link for the event on meetup.com, returned when fields request parameter value includes "short_link"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="simple_html_description"><span class="">simple_html_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the event, in simple HTML source format. If this event's description was saved in simple HTML format, the description field will be an HTML translation of this source. Returned when the "fields"' request parameter contains "simple_html_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>Status of the event. May be one of
+"upcoming" or "past"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+    <dd class="rounded-all">
+    <p>List of organizer-defined survey questions intended to be asked of RSVPing members. Returned when the "fields"' request parameter contains "answers"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric question identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="question"><span class="">question</span></dt>
+       <dd class="rounded-all">
+        <p>Question text</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="time"><span class="">time</span></dt>
+    <dd class="rounded-all">
+    <p>UTC start time of the event, in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="updated"><span class="">updated</span></dt>
+    <dd class="rounded-all">
+    <p>Last modified time for the event in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+    <dd class="rounded-all">
+    <p>The local offset from UTC time, in milliseconds</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="venue"><span class="">venue</span></dt>
+    <dd class="rounded-all">
+    <p>The event venue, present only if selected and not hidden by an organizer</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="address_1"><span class="">address_1</span></dt>
+       <dd class="rounded-all">
+        <p>Line 1 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="address_2"><span class="">address_2</span></dt>
+       <dd class="rounded-all">
+        <p>Line 2 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="address_3"><span class="">address_3</span></dt>
+       <dd class="rounded-all">
+        <p>Line 3 of venue address</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="city"><span class="">city</span></dt>
+       <dd class="rounded-all">
+        <p>City of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="country"><span class="">country</span></dt>
+       <dd class="rounded-all">
+        <p>Country code of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric venue id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+       <dd class="rounded-all">
+        <p>The localized name of the venue's country</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Approximate longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Venue name</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="phone"><span class="">phone</span></dt>
+       <dd class="rounded-all">
+        <p>Phone number of venue</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="repinned"><span class="">repinned</span></dt>
+       <dd class="rounded-all">
+        <p>true if the editor of the event altered the original venues pin location, false otherwise</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="state"><span class="">state</span></dt>
+       <dd class="rounded-all">
+        <p>State of venue where available</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="zip"><span class="">zip</span></dt>
+       <dd class="rounded-all">
+        <p>ZIP code if, venue is in US or Canada</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="venue_visibility"><span class="">venue_visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Represents who can see the venue with a potential value of "members" or "public", returned when fields request parameter value includes "venue_visibility" and the authenticated member is a member of the group hosting the event</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Event visibility: "public", "public_limited", or "members". Events in private groups that do not expose limited information are visible only to that group's members and should not be made public.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of members on the waitlist, if one exists</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="web_actions"><span class="">web_actions</span></dt>
+    <dd class="rounded-all">
+    <p>Set of "Invite" and google/yahoo/ical/outlook "Add to calendar" web actions</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="why"><span class="">why</span></dt>
+    <dd class="rounded-all">
+    <p>We should do this because...</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+    <dd class="rounded-all">
+    <p>Number of yes RSVPs including guests</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_self_groups.html
+++ b/test/data/_self_groups.html
@@ -1,0 +1,1417 @@
+
+        
+
+<div id="">
+  <h2>Member groups</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /self/groups
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Lists the authenticated member's groups in the order of leadership,
+next upcoming event, then alphabetical order by name</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/self/groups">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>This endpoint uses HTTP <a href="/meetup_api/docs/#v3_json">Link header based pagination</a>.</p></div>
+  <dl class="rounded-all">
+  
+    <dt class="align-right bold" title="fields"><span class="">fields</span></dt>
+    <dd class="rounded-all"><p>A comma-delimited list of optional fields to append to the response</p></dd>
+  
+    <dt class="align-right bold" title="page"><span class="">page</span></dt>
+    <dd class="rounded-all"><p>Number of groups to return in a single page of results.
+By default, this is 200</p></dd>
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>Returns a list of group objects encoded as JSON</p>
+  <dl>
+   
+    <dt class="align-right bold" title="approved"><span class="">approved</span></dt>
+    <dd class="rounded-all">
+    <p>Boolean indicator for whether this Group has been approved or not.
+New Groups are generally approved (or removed)
+soon after creation.
+Returned when the "fields" request parameter value includes
+"approved"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="category"><span class="">category</span></dt>
+    <dd class="rounded-all">
+    <p>The primary category of the group, if the group has one</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric category id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>String identifier of the category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name used for sorting</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city"><span class="">city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="city_link"><span class="">city_link</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, a URL for the group's city</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="contributions"><span class="">contributions</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field containing the contribution details of the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="enabled"><span class="">enabled</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean stating if contributions are enabled for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="potential"><span class="">potential</span></dt>
+       <dd class="rounded-all">
+        <p>Boolean stating that potential contributions are enabled for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="reason"><span class="">reason</span></dt>
+       <dd class="rounded-all">
+        <p>The reason a member might consider contributing</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thanks"><span class="">thanks</span></dt>
+       <dd class="rounded-all">
+        <p>The 'thank you' message to be given when a contribution is made</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="country"><span class="">country</span></dt>
+    <dd class="rounded-all">
+    <p>Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="created"><span class="">created</span></dt>
+    <dd class="rounded-all">
+    <p>Time the group was created in milliseconds since the epoch</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="description"><span class="">description</span></dt>
+    <dd class="rounded-all">
+    <p>Short description of group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="discussion_preferences"><span class="">discussion_preferences</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field that contains preference and permission data for group discussions</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="draft_event_count"><span class="">draft_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of draft events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="event_sample"><span class="">event_sample</span></dt>
+    <dd class="rounded-all">
+    <p>A small sampling of upcoming events.
+Returned when the "fields" request parameter
+value contains "event_sample"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_album"><span class="">photo_album</span></dt>
+       <dd class="rounded-all">
+        <p>Information about photo uploads for this event</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="event"><span class="">event</span></dt>
+            <dd class="rounded-all"><p>Event photo album belongs to. This will be absent if the album
+is not associated with an event</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for photo album</p></dd>
+            
+            <dt class="align-right bold" title="photo_count"><span class="">photo_count</span></dt>
+            <dd class="rounded-all"><p>Number of photos uploaded</p></dd>
+            
+            <dt class="align-right bold" title="photo_sample"><span class="">photo_sample</span></dt>
+            <dd class="rounded-all"><p>A small collection of photos uploaded for this event</p></dd>
+            
+            <dt class="align-right bold" title="title"><span class="">title</span></dt>
+            <dd class="rounded-all"><p>Album title</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="self"><span class="">self</span></dt>
+       <dd class="rounded-all">
+        <p>Represents details particular to the authorized user, only present
+if requested and authenticated member is a member of the hosting group,
+returned when "fields" request parameter value
+includes "self"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+            <dd class="rounded-all"><p>List of actions the authenticated member may perform, potentially one or more of the following</p>
+<p>"announce" to announce the event to the group's members</p>
+<p>"attendance" to view or take attendance for the event</p>
+<p>"copy" the ability to copy an event</p>
+<p>"comment" the ability to post a comment or reply</p>
+<p>"payments" the ability to mark members as paid if the event is ticketed</p>
+<p>"publish" to publish a draft event</p>
+<p>"edit" to edit the event information</p>
+<p>"edit_hosts" to edit the hosts for the event</p>
+<p>"email_attendees" the ability to email event attendees</p>
+<p>"delete" to delete the event</p>
+<p>"rsvp" to RSVP yes or no to the event</p>
+<p>"wait" to get on the waiting list (using the same RSVP methods).</p>
+<p>"dues" if an organizer requires membership dues to RSVP and the authorized
+ member has not paid theirs</p>
+<p>"upload_photo" the ability to upload a photo for the event</p>
+<p>"cancel" the ability to cancel the event</p>
+<p>"close" the ability to close the RSVPs for the event</p>
+<p>"open" the ability to open the RSVPs for the event</p>
+<p>"invite" the ability to invite someone for the event</p>
+<p>"download_attendees" the ability to download the attendees list for the event</p>
+<p>"take_attendance" the ability to take attendance for the event</p>
+<p>"delete_cancelled" the ability to delete the event if it is cancelled</p></dd>
+            
+            <dt class="align-right bold" title="pay_status"><span class="">pay_status</span></dt>
+            <dd class="rounded-all"><p>The authenticated member's payment status. This may be one of 'none', 'paid', 'partially_paid', 'payment_pending', 'echeck_pending', 'refund_pending', 'partially_refunded', 'refunded'</p></dd>
+            
+            <dt class="align-right bold" title="role"><span class="">role</span></dt>
+            <dd class="rounded-all"><p>The authenticated member's role in within the group, if any. This may be one of: Organizer, Assistant Organizer, Event Organizer, etc.</p></dd>
+            
+            <dt class="align-right bold" title="rsvp"><span class="">rsvp</span></dt>
+            <dd class="rounded-all"><p>Member's RSVP, if any</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="series"><span class="">series</span></dt>
+       <dd class="rounded-all">
+        <p>Returned when the "fields" request parameter value includes 
+"series" for events that are part of a series of events</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="description"><span class="">description</span></dt>
+            <dd class="rounded-all"><p>Human displayable description of how often events in this series occur</p></dd>
+            
+            <dt class="align-right bold" title="end_date"><span class="">end_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series ends/ended, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the series</p></dd>
+            
+            <dt class="align-right bold" title="monthly"><span class="">monthly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a monthly recurring series of events</p></dd>
+            
+            <dt class="align-right bold" title="start_date"><span class="">start_date</span></dt>
+            <dd class="rounded-all"><p>Date when this series begins/began, in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="template_event_id"><span class="">template_event_id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the template event of the series</p></dd>
+            
+            <dt class="align-right bold" title="weekly"><span class="">weekly</span></dt>
+            <dd class="rounded-all"><p>Returned for events that are part of a weekly recurring series of events</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="survey_questions"><span class="">survey_questions</span></dt>
+       <dd class="rounded-all">
+        <p>Contains a list of organizer-defined survey questions intended to be asked of RSVPing members.
+Returned when the "fields" request parameter</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric question identifier</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>Question text</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="fee_options"><span class="">fee_options</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, returns payment options for event ticketing</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currencies"><span class="">currencies</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable currencies for the payment method specified by type</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="code"><span class="">code</span></dt>
+            <dd class="rounded-all"><p>Currency accepted for fee</p></dd>
+            
+            <dt class="align-right bold" title="default"><span class="">default</span></dt>
+            <dd class="rounded-all"><p>A boolean set to true if the currency is the group's default currency, false otherwise</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="is_setup"><span class="">is_setup</span></dt>
+       <dd class="rounded-all">
+        <p>A boolean set to true if the payment method specified by 'type' is set up for the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="setup_link"><span class="">setup_link</span></dt>
+       <dd class="rounded-all">
+        <p>The URL for setting up the payment method specified by 'type'. This is returned if the payment method specified by 'type' is not set up for the group and the member has the permission to set it up</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Acceptable methods of payments may be one of Set(stripe, wepay, paypal, none, cash)</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="group_photo"><span class="">group_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Group photo</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="id"><span class="">id</span></dt>
+    <dd class="rounded-all">
+    <p>Numeric group ID</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="is_simplehtml"><span class="">is_simplehtml</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, 'true' when the group description has been saved in a simplified HTML format, 'false' otherwise.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_info"><span class="">join_info</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, lists any questions requested when joining and required fields</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="photo_req"><span class="">photo_req</span></dt>
+       <dd class="rounded-all">
+        <p>true if required, false otherwise</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="questions"><span class="">questions</span></dt>
+       <dd class="rounded-all">
+        <p>List of profile questions organizer would like new members to answer prior to joining</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Unique numeric identifier for the question</p></dd>
+            
+            <dt class="align-right bold" title="question"><span class="">question</span></dt>
+            <dd class="rounded-all"><p>The text of the question</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="questions_req"><span class="">questions_req</span></dt>
+       <dd class="rounded-all">
+        <p>true if required, false otherwise</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+    <dd class="rounded-all">
+    <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="key_photo"><span class="">key_photo</span></dt>
+    <dd class="rounded-all">
+    <p>Group primary photo</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+    <dd class="rounded-all">
+    <p>Lang of founder or coordinator</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="last_event"><span class="">last_event</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the last hosted event, if the group has one. Returned when the "fields" request parameter value contains "last_event"</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+    <dd class="rounded-all">
+    <p>Latitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="leader_limit"><span class="">leader_limit</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup leaders limit in group (4 leaders for the Basic Subscription), note this info available only for orgs and coorgs</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="leads"><span class="">leads</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the number of members on this group's leadership team. Returned when the "fields" request parameter value contains "leads"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="link"><span class="">link</span></dt>
+    <dd class="rounded-all">
+    <p>Link to group on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="list_addr"><span class="">list_addr</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field returning list address prefix. List mail will be {list_addr}-list@meetup.com. Announce email will be {list_addr}-announce@meetup.com. You must be a member of the group to see this</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="list_mode"><span class="">list_mode</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field representing the policy for who can post the group mailing list. Returned when the "fields" request parameter value contains "list_mode". Value may be one of "moderated", "off", "open", or "orgs_only"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_country_name"><span class="">localized_country_name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="localized_location"><span class="">localized_location</span></dt>
+    <dd class="rounded-all">
+    <p>City/State or City/Country of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+    <dd class="rounded-all">
+    <p>Longitude</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_cap"><span class="">member_cap</span></dt>
+    <dd class="rounded-all">
+    <p>Number representing the maximum number of active members this group can have if capped. Returned only when requested in the fields request parameter and the authenticated member has permission to approve members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="member_limit"><span class="">member_limit</span></dt>
+    <dd class="rounded-all">
+    <p>Meetup members limit in group (now it's 50 members in the Basic Subscription)</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="members"><span class="">members</span></dt>
+    <dd class="rounded-all">
+    <p>Number of Meetup members in this group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, returns membership dues for group if any</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="currency"><span class="">currency</span></dt>
+       <dd class="rounded-all">
+        <p>Currency in which the fee is declared</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="dues_links"><span class="">dues_links</span></dt>
+       <dd class="rounded-all">
+        <p>Links to dues management and checkout pages.</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="checkout_url"><span class="">checkout_url</span></dt>
+            <dd class="rounded-all"><p>Dues checkout page URL</p></dd>
+            
+            <dt class="align-right bold" title="settings_url"><span class="">settings_url</span></dt>
+            <dd class="rounded-all"><p>(Organizers only) Dues settings page URL</p></dd>
+            
+            <dt class="align-right bold" title="start_url"><span class="">start_url</span></dt>
+            <dd class="rounded-all"><p>(Organizers only) Dues setup page URL</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="fee"><span class="">fee</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric fee value</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="fee_desc"><span class="">fee_desc</span></dt>
+       <dd class="rounded-all">
+        <p>The interval at which dues must be paid. Possible values may include: "month", "year", "day", or "every other day"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="methods"><span class="">methods</span></dt>
+       <dd class="rounded-all">
+        <p>Methods of payments</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="amazon_payments"><span class="">amazon_payments</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Amazon Payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="credit_card"><span class="">credit_card</span></dt>
+            <dd class="rounded-all"><p>(Deprecated - use <code>wepay</code> or <code>stripe</code> instead) Boolean indicator that credit cards are accepted</p></dd>
+            
+            <dt class="align-right bold" title="other"><span class="">other</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that other forms of payment are accepted</p></dd>
+            
+            <dt class="align-right bold" title="paypal"><span class="">paypal</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Paypal payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="stripe"><span class="">stripe</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Stripe payments are accepted</p></dd>
+            
+            <dt class="align-right bold" title="wepay"><span class="">wepay</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator that Wepay payments are accepted</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="reasons"><span class="">reasons</span></dt>
+       <dd class="rounded-all">
+        <p>Array of reasons containing one or more of the following values compensate_organizer, cover_costs, encourage_engagement, improve_meetups, other, provide_supplies, reserve_fund</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="reasons_other"><span class="">reasons_other</span></dt>
+       <dd class="rounded-all">
+        <p>An additional reason if specified.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="refund_policy"><span class="">refund_policy</span></dt>
+       <dd class="rounded-all">
+        <p>Conditions for refunds</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="custom"><span class="">custom</span></dt>
+            <dd class="rounded-all"><p>Boolean indicator of a custom refund policy</p></dd>
+            
+            <dt class="align-right bold" title="group_closes"><span class="">group_closes</span></dt>
+            <dd class="rounded-all"><p>refund applies when the group closes</p></dd>
+            
+            <dt class="align-right bold" title="member_banned"><span class="">member_banned</span></dt>
+            <dd class="rounded-all"><p>refund applies when the member is banned</p></dd>
+            
+            <dt class="align-right bold" title="member_leaves"><span class="">member_leaves</span></dt>
+            <dd class="rounded-all"><p>refund applies when member leaves the group</p></dd>
+            
+            <dt class="align-right bold" title="none"><span class="">none</span></dt>
+            <dd class="rounded-all"><p>indicates there is no refund policy</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="required"><span class="">required</span></dt>
+       <dd class="rounded-all">
+        <p>true if dues are required</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="required_to"><span class="">required_to</span></dt>
+       <dd class="rounded-all">
+        <p>If the dues are required this indicates what they are required for. Currently may only be 'join'</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="self_payment_required"><span class="">self_payment_required</span></dt>
+       <dd class="rounded-all">
+        <p>Returns true if the authorized user is prevented from participating in the group until a payment is made</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="trial_days"><span class="">trial_days</span></dt>
+       <dd class="rounded-all">
+        <p>When present, returns the number of days the group is offering a free trial period for to new members. When not present, this indicates that the group does not offer a trial membership period</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="meta_category"><span class="">meta_category</span></dt>
+    <dd class="rounded-all">
+    <p>The meta category of the group, if the group has one</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="best_topics"><span class="">best_topics</span></dt>
+       <dd class="rounded-all">
+        <p>Represents the best topic matches for this category, returned when the "fields"
+request parameter value includes "best_topics"</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric topic id</p></dd>
+            
+            <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+            <dd class="rounded-all"><p>Language topic originates from</p></dd>
+            
+            <dt class="align-right bold" title="name"><span class="">name</span></dt>
+            <dd class="rounded-all"><p>Display name of the topic</p></dd>
+            
+            <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+            <dd class="rounded-all"><p>The unique keyword used to identify this topic</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="category_ids"><span class="">category_ids</span></dt>
+       <dd class="rounded-all">
+        <p>List of numeric category ids associated with this topic category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic-category id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic-category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Photo representing this category</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="shortname"><span class="">shortname</span></dt>
+       <dd class="rounded-all">
+        <p>Unique string identifier for this category</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="sort_name"><span class="">sort_name</span></dt>
+       <dd class="rounded-all">
+        <p>Name used for sorting</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="name"><span class="">name</span></dt>
+    <dd class="rounded-all">
+    <p>Name of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="next_event"><span class="">next_event</span></dt>
+    <dd class="rounded-all">
+    <p>The current ongoing or next upcoming event, if one is scheduled</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Alphanumeric event ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of event</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="no_rsvp_count"><span class="">no_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of no RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="time"><span class="">time</span></dt>
+       <dd class="rounded-all">
+        <p>UTC start time of the event, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="utc_offset"><span class="">utc_offset</span></dt>
+       <dd class="rounded-all">
+        <p>The local offset from UTC time, in milliseconds</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="waitlist_count"><span class="">waitlist_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of waitlisted RSVPs, included if the rsvp_counts field is set</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="yes_rsvp_count"><span class="">yes_rsvp_count</span></dt>
+       <dd class="rounded-all">
+        <p>Number of yes RSVPs</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="nominated_member"><span class="">nominated_member</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns if the logged in member has been nominated to take over the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="organizer"><span class="">organizer</span></dt>
+    <dd class="rounded-all">
+    <p>Group's primary organizer</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="bio"><span class="">bio</span></dt>
+       <dd class="rounded-all">
+        <p>Bio of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric member ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of member</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo"><span class="">photo</span></dt>
+       <dd class="rounded-all">
+        <p>Organizer photo, where defined</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="past_event_count"><span class="">past_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of past events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="pending_members"><span class="">pending_members</span></dt>
+    <dd class="rounded-all">
+    <p>Number representing the count of members pending organizer approval to join. Returned only when requested in the fields request parameter and the authenticated member has permission to approve members</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photo_gradient"><span class="">photo_gradient</span></dt>
+    <dd class="rounded-all">
+    <p>Color combination used generate group duotone</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="composite_color"><span class="">composite_color</span></dt>
+       <dd class="rounded-all">
+        <p>Composite color in hexidecimal format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="dark_color"><span class="">dark_color</span></dt>
+       <dd class="rounded-all">
+        <p>Dark color in hexidecimal format</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Unique numeric identifier</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="light_color"><span class="">light_color</span></dt>
+       <dd class="rounded-all">
+        <p>Light color in hexidecimal format</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="photos"><span class="">photos</span></dt>
+    <dd class="rounded-all">
+    <p>A small set of photos from the group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+       <dd class="rounded-all">
+        <p>A base url that can be use to construct a photo url from its components</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for full sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric photo ID</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for standard sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+       <dd class="rounded-all">
+        <p>Link for thumbnail sized photo</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="type"><span class="">type</span></dt>
+       <dd class="rounded-all">
+        <p>Type of photo. One of "event" or "member"</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_description"><span class="">plain_text_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in plain text format. Returned when then "fields" request parameter value contains "plain_text_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="plain_text_no_images_description"><span class="">plain_text_no_images_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in plain text format with no images. Returned when then "fields" request parameter value contains "plain_text_no_images_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="proposed_event_count"><span class="">proposed_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of proposed events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="self"><span class="">self</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, contains details specific to the authorized user in this Meetup Group</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="actions"><span class="">actions</span></dt>
+       <dd class="rounded-all">
+        <p>List of actions the authenticated member may perform, potentially "broadcast_message": the ability to broadcast messages to group members via the "announce" mailing list, "event_create": the ability to create new events, "event_draft": the ability to save new events as drafts, "role_assign": the ability to assign member roles, "edit": the ability to edit group settings, "member_approval": the ability to approve or decline member requests to join, or "subscription_upgrade": the ability to upgrade this group's subscription plan</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="membership_dues"><span class="">membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Member's membership dues if the group has membership dues</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="cancelled"><span class="">cancelled</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that membership dues were cancelled</p></dd>
+            
+            <dt class="align-right bold" title="exempt"><span class="">exempt</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that the member is exempt from payment.</p></dd>
+            
+            <dt class="align-right bold" title="paid_until"><span class="">paid_until</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns the time in milliseconds since the epoch that the member's next payment is due</p></dd>
+            
+            <dt class="align-right bold" title="period_status"><span class="">period_status</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns one of the following values grace paid pending unpaid</p></dd>
+            
+            <dt class="align-right bold" title="total_amount"><span class="">total_amount</span></dt>
+            <dd class="rounded-all"><p>Total amount paid</p></dd>
+            
+            <dt class="align-right bold" title="transaction_time"><span class="">transaction_time</span></dt>
+            <dd class="rounded-all"><p>Time the transaction was made in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="trial"><span class="">trial</span></dt>
+            <dd class="rounded-all"><p>If the group offers a trial membership, this indicates information for unpaid members.</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="previous_membership_dues"><span class="">previous_membership_dues</span></dt>
+       <dd class="rounded-all">
+        <p>Member's membership dues history when currently not a part of group i.e Status=none if the group has membership dues</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="cancelled"><span class="">cancelled</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that membership dues were cancelled</p></dd>
+            
+            <dt class="align-right bold" title="exempt"><span class="">exempt</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this Boolean field indicates that the member is exempt from payment.</p></dd>
+            
+            <dt class="align-right bold" title="paid_until"><span class="">paid_until</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns the time in milliseconds since the epoch that the member's next payment is due</p></dd>
+            
+            <dt class="align-right bold" title="period_status"><span class="">period_status</span></dt>
+            <dd class="rounded-all"><p>For groups with recurring billing periods, this returns one of the following values grace paid pending unpaid</p></dd>
+            
+            <dt class="align-right bold" title="total_amount"><span class="">total_amount</span></dt>
+            <dd class="rounded-all"><p>Total amount paid</p></dd>
+            
+            <dt class="align-right bold" title="transaction_time"><span class="">transaction_time</span></dt>
+            <dd class="rounded-all"><p>Time the transaction was made in milliseconds since the epoch</p></dd>
+            
+            <dt class="align-right bold" title="trial"><span class="">trial</span></dt>
+            <dd class="rounded-all"><p>If the group offers a trial membership, this indicates information for unpaid members.</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="role"><span class="">role</span></dt>
+       <dd class="rounded-all">
+        <p>Member's role in group, if any: Organizer, Assistant Organizer, Event Organizer, etc.</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="status"><span class="">status</span></dt>
+       <dd class="rounded-all">
+        <p>Indicates the authorized user's membership with this group. Value may be one of "none", "pending", "pending_payment", "active", or "blocked"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="visited"><span class="">visited</span></dt>
+       <dd class="rounded-all">
+        <p>Member's last visit to the group site, in milliseconds since the epoch</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="short_link"><span class="">short_link</span></dt>
+    <dd class="rounded-all">
+    <p>Optional field, a shorted URL for the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="similar_groups"><span class="">similar_groups</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns up to 5 groups similar to this groups, best suited for the authenticated member when a single group is queried for. Note: this field is being deprecated in favor of making a separate request to /:urlname/similar_groups</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Id of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="join_mode"><span class="">join_mode</span></dt>
+       <dd class="rounded-all">
+        <p>Who can join this group and how. One of "approval", "closed", or "open"</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lat"><span class="">lat</span></dt>
+       <dd class="rounded-all">
+        <p>Latitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lon"><span class="">lon</span></dt>
+       <dd class="rounded-all">
+        <p>Longitude</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Name of the group</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="photos"><span class="">photos</span></dt>
+       <dd class="rounded-all">
+        <p>Optional fields parameter. A small set of photos from the group</p>
+        
+          <dl>
+            
+            <dt class="align-right bold" title="base_url"><span class="">base_url</span></dt>
+            <dd class="rounded-all"><p>A base url that can be use to construct a photo url from its components</p></dd>
+            
+            <dt class="align-right bold" title="highres_link"><span class="">highres_link</span></dt>
+            <dd class="rounded-all"><p>Link for full sized photo</p></dd>
+            
+            <dt class="align-right bold" title="id"><span class="">id</span></dt>
+            <dd class="rounded-all"><p>Numeric photo ID</p></dd>
+            
+            <dt class="align-right bold" title="photo_link"><span class="">photo_link</span></dt>
+            <dd class="rounded-all"><p>Link for standard sized photo</p></dd>
+            
+            <dt class="align-right bold" title="thumb_link"><span class="">thumb_link</span></dt>
+            <dd class="rounded-all"><p>Link for thumbnail sized photo</p></dd>
+            
+            <dt class="align-right bold" title="type"><span class="">type</span></dt>
+            <dd class="rounded-all"><p>Type of photo. One of "event" or "member"</p></dd>
+            
+          <dl>
+        
+       </dl></dl></dd>
+      
+       <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+       <dd class="rounded-all">
+        <p>Urlname used to identify the group on meetup.com</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="who"><span class="">who</span></dt>
+       <dd class="rounded-all">
+        <p>What this group calls it's members</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="simple_html_description"><span class="">simple_html_description</span></dt>
+    <dd class="rounded-all">
+    <p>Description of the group, in simple HTML source format. If this group's description was saved in simple HTML format, the description field will be an HTML translation of this source. Returned when the "fields" request parameter value contains "simple_html_description"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="state"><span class="">state</span></dt>
+    <dd class="rounded-all">
+    <p>State of the group, if in US or Canada</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>Status of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="timezone"><span class="">timezone</span></dt>
+    <dd class="rounded-all">
+    <p>This represents the universal timezone identifier for the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="topics"><span class="">topics</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the group's topics</p>
+    
+      <dl>
+      
+       <dt class="align-right bold" title="id"><span class="">id</span></dt>
+       <dd class="rounded-all">
+        <p>Numeric topic id</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="lang"><span class="">lang</span></dt>
+       <dd class="rounded-all">
+        <p>Language topic originates from</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="name"><span class="">name</span></dt>
+       <dd class="rounded-all">
+        <p>Display name of the topic</p>
+        
+       </dd>
+      
+       <dt class="align-right bold" title="urlkey"><span class="">urlkey</span></dt>
+       <dd class="rounded-all">
+        <p>The unique keyword used to identify this topic</p>
+        
+       </dd>
+      
+      </dl>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="untranslated_city"><span class="">untranslated_city</span></dt>
+    <dd class="rounded-all">
+    <p>City of the group, not translated</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="upcoming_event_count"><span class="">upcoming_event_count</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the number of upcoming events belonging to the group.</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="urlname"><span class="">urlname</span></dt>
+    <dd class="rounded-all">
+    <p>Urlname used to identify the group on meetup.com</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="visibility"><span class="">visibility</span></dt>
+    <dd class="rounded-all">
+    <p>Who can see this group. One of members, public or public_limited</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="welcome_message"><span class="">welcome_message</span></dt>
+    <dd class="rounded-all">
+    <p>Optional fields parameter. Returns the Group's default welcome message if the authenticated member is the organizer of the group</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="who"><span class="">who</span></dt>
+    <dd class="rounded-all">
+    <p>What the group calls its members</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/data/_status.html
+++ b/test/data/_status.html
@@ -1,0 +1,76 @@
+
+        
+
+<div id="">
+  <h2>API Status</h2>
+  <div id="uri" class="uri rounded-all">
+    <div class="line">
+      <div class="unit" title="Request URI">
+        <strong class="muted caps">GET</strong> /status
+      </div>
+      <div class="lastUnit">
+        <ul class="formats align-right inlineList" title="Serialization formats">
+        
+          <li class="rounded-all api-label">json</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="unit">
+        <strong class="muted">Host:</strong> api.meetup.com
+      </div>
+      <div class="lastUnit">
+        <ul class="scopes align-right inlineList" title="Authorization scopes">
+        
+          <li class="rounded-all api-label">basic</li>
+        
+        </ul>
+      </div>
+    </div>
+    <div class="line">
+      <div class="lastUnit align-right">
+        <span class="rounded-all api-label">api version 3</span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="leading-top">
+  <p>Returns the current API service status</p>
+  </div>
+  <p><a href="/meetup_api/console/?path=/status">Try it in the console</a></p>
+  <h3 id="params" class="rounded-all">Request Parameters</h3>
+  <div class="param-notes"><p>No parameters are needed</p></div>
+  <dl class="rounded-all">
+  
+  </dl>
+  
+  <h3 id="response" class="rounded-all">Response</h3>
+  <p>Returns a JSON-encoded object reprsenting the current API service status</p>
+  <dl>
+   
+    <dt class="align-right bold" title="message"><span class="">message</span></dt>
+    <dd class="rounded-all">
+    <p>Optional message for display. May be absent</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="status"><span class="">status</span></dt>
+    <dd class="rounded-all">
+    <p>May be one of "ok", "notice", or "unavailable"</p>
+    
+    </dd>
+   
+    <dt class="align-right bold" title="title"><span class="">title</span></dt>
+    <dd class="rounded-all">
+    <p>Optional title for display. May be absent</p>
+    
+    </dd>
+  
+  </dl>
+  
+  
+</div>
+
+
+      

--- a/test/endpoint_info_test.dart
+++ b/test/endpoint_info_test.dart
@@ -13,12 +13,16 @@ void main() {
     /// The call to the scraper retrieves the html from the documentation
     /// page for the endpoint with path ':urlname/abuse_reports'
     /// and extracting the element with id='method-info'
-    test('correctly parses with fromElement', () async {
+    test('correctly parses a page with one endpoint info item', () async {
       final htmlString =
           await File('test/data/report-group.html').readAsString();
-      final element = parse(htmlString).documentElement!;
+      final document = parse(htmlString);
 
-      final endpointInfo = EndpointInfo.fromElement(element);
+      final h2s = document.getElementsByTagName('h2');
+      final title = h2s.first.text;
+      final idPrefix = h2s.first.parent!.id;
+
+      final endpointInfo = EndpointInfo(title, idPrefix, document, 0);
 
       expect(endpointInfo.title, 'Report Group');
       expect(endpointInfo.summary,
@@ -28,7 +32,7 @@ void main() {
       expect(endpointInfo.requestParameters.notes,
           'This method requires the oauth reporting scope for oauth-authenticated requests');
 
-      // there are just two request parameters described for this endpoint
+      // there are just two request parameters for this endpoint
       expect(endpointInfo.requestParameters.parameterSet.first.toString(),
           'comments: An optional string of text that describes why you are submitting this report');
       expect(endpointInfo.requestParameters.parameterSet.last.toString(),
@@ -41,15 +45,95 @@ void main() {
       // the examples section has a description and then the example
       expect(endpointInfo.examples!.notes,
           "Submit an abuse report for a group {urlname} that doesn't appear to be fostering a health community");
+      expect(
+          endpointInfo.examples!.example,
+          'curl -H "Authorization: Bearer {token}" \\\n'
+          '  "https://api.meetup.com/{urlname}/abuse_reports" \\\n'
+          '  -d "type=not_community"\n'
+          '');
+    });
 
-      // the strings here are close but not exactly the same - not sure if it's worth
-      // takong the time to fix it, will come back to it
-//       expect(endpointInfo.examples!.example, '''
-// curl -H "Authorization: Bearer {token}" \
-//   "https://api.meetup.com/{urlname}/abuse_reports" \
-//   -d "type=not_community"
-//     });
-// ''');
+    test('correctly parses a page with multiple endpoint info items', () async {
+      final htmlString =
+          await File('test/data/_members_:member_id.html').readAsString();
+      final document = parse(htmlString);
+
+      final h2s = document.getElementsByTagName('h2');
+      final title1 = h2s.first.text;
+      final idPrefix1 = h2s.first.parent!.id;
+
+      final endpointInfo1 = EndpointInfo(title1, idPrefix1, document, 0);
+
+      expect(endpointInfo1.title, 'Get Member Profile');
+      expect(
+          endpointInfo1.summary,
+          '\n'
+          '  Gets Member Profiles.\n'
+          'For Group Profiles, see this endpoint\n'
+          '  ');
+      expect(endpointInfo1.path, '/members/:member_id');
+      expect(endpointInfo1.operationType, OperationType.get);
+      expect(endpointInfo1.requestParameters.notes,
+          'A valid path parameter for :member_id is required. A value of "self"\nmay be used in place of a numeric identifier to represent the authenticated\nMember\'s id');
+
+      // there is just one request parameter for this endpoint
+      expect(endpointInfo1.requestParameters.parameterSet.first.toString(),
+          'fields: A comma-delimited string of optional response field names.\nThis may include groups, privacy, and topics');
+
+      // the response in this case only has a description
+      expect(endpointInfo1.response.toString(),
+          'Returns a single Member Profile object');
+
+      // the examples section has a description and then the example
+      expect(endpointInfo1.examples!.notes,
+          'Fetch your own profile with all your groups');
+      expect(
+          endpointInfo1.examples!.example,
+          'curl -H "Authorization: bearer {ACCESS_TOKEN}" \\\n'
+          '    "https://api.meetup.com/members/self?fields=groups"\n'
+          '');
+
+      final title2 = h2s.last.text;
+      final idPrefix2 = h2s.last.parent!.id;
+
+      final endpointInfo2 = EndpointInfo(title2, idPrefix2, document, 1);
+
+      expect(endpointInfo2.title, 'Member Profile Edit');
+      expect(
+          endpointInfo2.summary,
+          '\n'
+          '  \n'
+          '  ');
+      expect(endpointInfo2.path, '/members/:member_id');
+      expect(endpointInfo2.operationType, OperationType.patch);
+      expect(
+          endpointInfo2.requestParameters.notes,
+          'All parameters are optional.\n'
+          'OAuth authenticated applications should\n'
+          'request the profile_edit\n'
+          'permission scope\n'
+          'Some Meetup group organizers may define a set of profile questions\n'
+          'they\'d like their members to answer. You can obtain that question\n'
+          'list using the Get Group by sending\n'
+          ' a "fields" request parameter containing\n'
+          '"join_info"\n'
+          'The authenticated member may set their currently location by either supplying a valid\n'
+          '"city_id" or a valid "lat", "lon", or "zip".\n'
+          'You can resolve a coordinate-based "zip" by using the\n'
+          'Find locations API');
+
+      // one request parameter for this endpoint
+      expect(endpointInfo2.requestParameters.parameterSet.first.toString(),
+          'add_topics: Comma-delimited list of topic ids to add to members interest list');
+
+      // the response in this case only has a description
+      expect(
+          endpointInfo2.response.toString(),
+          'A successful HTTP PATCH request will return an\n'
+          'updated representation of the Member Profile');
+
+      // the examples section has a description and then the example
+      expect(endpointInfo2.examples, null);
     });
   });
 }

--- a/test/split_endpoint_infos_test.dart
+++ b/test/split_endpoint_infos_test.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+import 'package:html/parser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('EndpointInfos', () {
+    test('can be split by...', () async {
+      final htmlString =
+          await File('test/data/_members_:member_id.html').readAsString();
+
+      final document = parse(htmlString);
+
+      final h2s = document.getElementsByTagName('h2');
+      for (final element in h2s) {
+        final title = element.text;
+        final id = element.parent?.id;
+      }
+    });
+  });
+}


### PR DESCRIPTION
- changed EndpointInfo from using a 'fromElement' factory constructor to
  a regular constructor
- updated EndpointInfo constructor to take parameters that allow for
  selecting elements when there is more than one endpoint infos
- added files for testing consisting of elements selected from the
  endpoint pages
- added more tests